### PR TITLE
Added explanation about use of Geopackage

### DIFF
--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1974,7 +1974,7 @@ class ObsCollection(pd.DataFrame):
         Parameters
         ----------
         fname : str
-            filename of shapefile (.shp) or geopackage (.gpkg). A Geopackage
+            filename of shapefile (.shp) or geopackage (.gpkg). A geopackage
             has the advantage that column names will not be truncated.
         xcol : str
             column name with x values

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1974,10 +1974,8 @@ class ObsCollection(pd.DataFrame):
         Parameters
         ----------
         fname : str
-            filename of shapefile, ends with .shp
-            
-            In order to export to Geopackage, use .gpkg as extension.
-            This has the advantage that column names will not be truncated.
+            filename of shapefile (.shp) or geopackage (.gpkg). A Geopackage
+            has the advantage that column names will not be truncated.
         xcol : str
             column name with x values
         ycol : str

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1975,6 +1975,9 @@ class ObsCollection(pd.DataFrame):
         ----------
         fname : str
             filename of shapefile, ends with .shp
+            
+            In order to export to Geopackage, use .gpkg as extension.
+            This has the advantage that column names will not be truncated.
         xcol : str
             column name with x values
         ycol : str


### PR DESCRIPTION
I tried to export to geopackage, which actually works. That has advantages over shapefile (column names not being truncated, possible fewer limitations when it comes to datatypes).