### PR TITLE
Update some log-messages and improve fill_missing_measurements in knmi

### DIFF
--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -175,7 +175,7 @@ def _get_default_settings(settings=None):
     only the non-existing settings are added with their default value.
 
     The default settings are:
-    fill_missing_obs = True
+    fill_missing_obs = False
         nan values in time series are filled with nearby time series.
     interval = 'daily'
         desired time interval for observations. Can be 'daily' or 'hourly'.
@@ -1447,7 +1447,7 @@ def _check_latest_measurement_date_de_bilt(
 
     last_measurement_date_debilt = knmi_df.index[-1]
 
-    logger.info(
+    logger.debug(
         f"last {meteo_var} measurement available at the Bilt until {end_str} is from"
         f' {last_measurement_date_debilt.strftime("%Y-%m-%d")}'
     )

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -439,7 +439,7 @@ def fill_missing_measurements(stn, meteo_var, start, end, settings, stn_name=Non
     )
     if knmi_df.empty or (end > knmi_df.index[-1]):
         # check latest date at which measurements are available at De Bilt
-        new_end = _check_latest_measurement_date_debilt(
+        new_end = _check_latest_measurement_date_de_bilt(
             meteo_var,
             use_api=settings["use_api"],
             start=None if knmi_df.empty else knmi_df.index[-1],
@@ -1373,7 +1373,7 @@ def read_knmi_hourly(f, meteo_var, start=None, end=None):
     return df.loc[start:end, [meteo_var]], variables
 
 
-def _check_latest_measurement_date_debilt(
+def _check_latest_measurement_date_de_bilt(
     meteo_var, use_api=True, start=None, end=None
 ):
     """According to the website of the knmi it can take up to 3 weeks before
@@ -1395,6 +1395,12 @@ def _check_latest_measurement_date_debilt(
         if True the api is used to obtain the data, API documentation is here:
             https://www.knmi.nl/kennis-en-datacentrum/achtergrond/data-ophalen-vanuit-een-script
         Default is True.
+    start : pd.TimeStamp or None, optional
+        start date of observations. Set to 365 days before today when None. The default
+        is None.
+    end : pd.TimeStamp or None, optional
+        end date of observations. Set to 10 days after today when None. The default is
+        None.
 
     Returns
     -------
@@ -1741,7 +1747,7 @@ def get_knmi_obslist(
                 )
             else:
                 raise ValueError(
-                    "stns, location and xy are all None. Please specify one of these"
+                    "stns, location and xy are all None. Please specify one of these arguments."
                 )
             _stns = np.unique(_stns)
 

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -1749,7 +1749,8 @@ def get_knmi_obslist(
                 )
             else:
                 raise ValueError(
-                    "stns, location and xy are all None. Please specify one of these arguments."
+                    "stns, location and xy are all None. "
+                    "Please specify one of these arguments."
                 )
             _stns = np.unique(_stns)
 

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -97,9 +97,12 @@ def get_knmi_obs(
     if stn is not None:
         stn = int(stn)
 
+        start_str = str(start).replace(" 00:00:00", "")
+        end_str = str(end).replace(" 00:00:00", "")
+
         logger.info(
-            f"get KNMI data from station {stn} and meteo variable {meteo_var} "
-            f"from {start} to {end}"
+            f"get data from station {stn} and variable {meteo_var} "
+            f"from {start_str} to {end_str}"
         )
         ts, meta = get_knmi_timeseries_stn(stn, meteo_var, settings, start, end)
     elif fname is not None:
@@ -476,7 +479,7 @@ def fill_missing_measurements(stn, meteo_var, start, end, settings, stn_name=Non
     knmi_df = _add_missing_indices(knmi_df, stn, start, end)
 
     missing = knmi_df[meteo_var].isna()
-    logger.info(f"station {stn} has {missing.sum()} missing measurements")
+    logger.debug(f"station {stn} has {missing.sum()} missing measurements")
 
     knmi_df.loc[~missing, "station"] = str(stn)
 
@@ -497,8 +500,9 @@ def fill_missing_measurements(stn, meteo_var, start, end, settings, stn_name=Non
         else:
             stn_comp = stn_comp[0]
 
+        n_missing = missing.sum()
         logger.info(
-            f"trying to fill {missing.sum()} measurements with station {stn_comp}"
+            f"trying to fill {n_missing} missing measurements with station {stn_comp}"
         )
 
         stn_name_comp = get_station_name(stn_comp, stations)


### PR DESCRIPTION
This PR improves some of the log-levels and log-messages in the knmi-module. One small but important change is that `download_knmi_data` does not display any info-messages anymore, but debug-messages. So users will generally only see log-messages from the method calling `download_knmi_data`.


On top of that `fill_missing_measurements` is improved: `fill_missing_measurements` does not check for station De Bilt anymore, if it has already successfully download data util `end`.