### PR TITLE
address figure filename in `series_per_group` #199

### DIFF
--- a/hydropandas/extensions/plots.py
+++ b/hydropandas/extensions/plots.py
@@ -647,7 +647,13 @@ class CollectionPlots:
         return fig, axes
 
     def series_per_group(
-        self, plot_column, by=None, savefig=True, outputdir=".", naming_method=None
+        self,
+        plot_column,
+        by=None,
+        savefig=True,
+        outputdir=".",
+        naming_method=None,
+        units_for_well_screen_depth="mNAP",
     ):
         """Plot time series per group.
 
@@ -676,6 +682,10 @@ class CollectionPlots:
             obtain the name of the monitoring well from the final name in the group,
             by splitting the string on "-" or "_", and using the first part.
             For example, if the name is "PB001-001", the filename will be "PB001.png".
+        units_for_well_screen_depth : str, optional
+            if the observations are GroundWaterObs, the units of the screen depth are
+            added to the legend. This keyword argument defines the units for the screen
+            depth. Default is 'mNAP'.
 
         Returns
         -------
@@ -694,10 +704,17 @@ class CollectionPlots:
             f, ax = plt.subplots(1, 1, figsize=(10, 3))
             for name, row in group.iterrows():
                 if isinstance(row.obs, GroundwaterObs):
-                    lbl = (
-                        f"{name} (NAP{row['screen_top']:+.1f}"
-                        f"-{row['screen_bottom']:+.1f}m)"
-                    )
+                    if units_for_well_screen_depth == "mNAP":
+                        lbl = (
+                            f"{name} (NAP{row['screen_top']:+.1f}"
+                            f"-{row['screen_bottom']:+.1f} m)"
+                        )
+                    else:
+                        lbl = (
+                            f"{name} ({row['screen_top']:.1f}"
+                            f"-{row['screen_bottom']:.1f} "
+                            f"{units_for_well_screen_depth})"
+                        )
                 else:
                     lbl = f"{name}"
                 ax.plot(

--- a/hydropandas/extensions/plots.py
+++ b/hydropandas/extensions/plots.py
@@ -716,12 +716,12 @@ class CollectionPlots:
             f.tight_layout()
 
             if savefig:
+                if isinstance(by, list):
+                    by_name = "-".join(by)
+                else:
+                    by_name = by
+                    groupname = "-".join(groupname)
                 if naming_method is None:
-                    if isinstance(by, list):
-                        by_name = "-".join(by)
-                        groupname = "-".join(groupname)
-                    else:
-                        by_name = by
                     filename = f"series_by_{by_name}_group_{groupname}.png"
                 elif naming_method == "infer_name_monitoring_well":
                     if "-" in name:
@@ -732,7 +732,7 @@ class CollectionPlots:
                         filename = f"{name}.png"
                 elif isinstance(naming_method, str):
                     filename = (
-                        "series_group_"
+                        f"series_by_{by_name}_group_"
                         f"{'-'.join(group[naming_method].unique().tolist())}.png"
                     )
 


### PR DESCRIPTION
Improve naming of resulting plots, following @HMEUW's suggestion.

I added an argument naming_method.
- if None: use template `"series_by_{by}_group_{values}.png"`
- if "infer_name_monitoring_well": uses last name from group to attempt inferring location code (splitting on "-" or "_" and taking the first part), e.g. "PB001-001" will become "PB001.png". I kept this option because I needed it once, but I'm sure there was a workaround I could have used, but keeping it in here for now. 
- if str, interpret as column name in group and collect unique values from that column, e.g. if group contains a column "unique_name" with values PB001, PB002, PB003 the resulting file name will be `"series_by_{by}_group_PB001-PB002-PB003.png"`

Also added that the function will return axes handles if `savefig=False`.