### PR TITLE
Deal with metadataheader not being present

### DIFF
--- a/hydropandas/io/dino.py
+++ b/hydropandas/io/dino.py
@@ -55,9 +55,9 @@ def _read_dino_groundwater_referencelvl(f, line):
 
 
 def _read_dino_groundwater_metadata(f, line):
-    if 'Peildatum' in line:
-        return line, {"metadata_available" : False}, {}
-    
+    if "Peildatum" in line:
+        return line, {"metadata_available": False}, {}
+
     _translate_dic_float = {
         "x-coordinaat": "x",
         "y-coordinaat": "y",

--- a/hydropandas/io/dino.py
+++ b/hydropandas/io/dino.py
@@ -55,6 +55,9 @@ def _read_dino_groundwater_referencelvl(f, line):
 
 
 def _read_dino_groundwater_metadata(f, line):
+    if 'Peildatum' in line:
+        return line, {"metadata_available" : False}, {}
+    
     _translate_dic_float = {
         "x-coordinaat": "x",
         "y-coordinaat": "y",


### PR DESCRIPTION
In B44H0400001 (I added the file + an other 'normal' file) no metadata and no metadata header is present, I got a keyerror exception, because the code tries to pop a key that would normally be in the metadata (it tried to pop 'startdatum'). 

In the proposed change is a way to deal with it, although there are many (maybe more chique) ways, so feel free to do it otherwise. btw I don't think there are a lot of files without metadata header, so maybe a try and except statement will do nicely

[B44F0279001.csv](https://github.com/ArtesiaWater/hydropandas/files/15041190/B44F0279001.csv)
[B44H0400001.csv](https://github.com/ArtesiaWater/hydropandas/files/15041191/B44H0400001.csv)
