### PR TITLE
Accept files with extension XML as well

### DIFF
--- a/hydropandas/io/solinst.py
+++ b/hydropandas/io/solinst.py
@@ -33,7 +33,7 @@ def read_solinst_file(
     # open file
     path = str(path)
     name = os.path.splitext(os.path.basename(path))[0]
-    if path.endswith(".xle"):
+    if path.endswith(tuple([".xle", ".xml"])):
         f = path
     elif path.endswith(".zip"):
         zf = zipfile.ZipFile(path)


### PR DESCRIPTION
When exporting data from the Solinst Levelogger Software, the extension '.xml' is used. Files with this extension can be read as well. So both XLE and XML should be accepted.