### PR TITLE
Some KNMI fixes

### DIFF
--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -399,9 +399,12 @@ def get_stations(
         meteo_var = "EV24"
 
     # select only stations with meteo_var
+    if meteo_var == slice(None):
+        meteo_mask = stations.loc[:, meteo_var].any(axis=1)
+    else:
+        meteo_mask = stations.loc[:, meteo_var]
     stations = stations.loc[
-        stations.loc[:, meteo_var],
-        ["lon", "lat", "name", "x", "y", "altitude", "tmin", "tmax"],
+        meteo_mask, ["lon", "lat", "name", "x", "y", "altitude", "tmin", "tmax"]
     ]
 
     # select only stations with measurement

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -408,7 +408,8 @@ def get_stations(
     ]
 
     # select only stations with measurement
-    stations = _get_stations_tmin_tmax(stations, start, end)
+    if start is not None or end is not None:
+        stations = _get_stations_tmin_tmax(stations, start, end)
 
     return stations
 

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -536,10 +536,13 @@ def fill_missing_measurements(
     if stn_name is None:
         stn_name = get_station_name(stn=stn, stations=stations)
 
-    # download data from station
+    # download data from station if it has data between start-end
     knmi_df, variables, station_meta = download_knmi_data(
         stn, meteo_var, start, end, settings, stn_name
     )
+    if stn not in stations.index:
+        # add current station to df to determine which station to fill data with
+        stations = pd.concat([stations, get_stations(meteo_var=meteo_var).loc[[stn]]])
 
     # if the first station cannot be read, read another station as the first
     ignore = [stn]
@@ -552,6 +555,7 @@ def fill_missing_measurements(
             meteo_var=meteo_var,
             start=start,
             end=end,
+            stations=stations,
             ignore=ignore,
         )
         if stn_lst is None:

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -484,7 +484,9 @@ def get_station_name(stn: int, stations: Union[pd.DataFrame, None] = None) -> st
 
     stn_name = stations.at[stn, "name"]
     if isinstance(stn_name, pd.Series):
-        raise ValueError(f'station {stn} is a meteo- and a precipitation station, please indicate which one you want to use using a "meteo_var"')
+        raise ValueError(
+            f'station {stn} is a meteo- and a precipitation station, please indicate which one you want to use using a "meteo_var"'
+        )
 
     stn_name = stn_name.upper().replace(" ", "-").replace("(", "").replace(")", "")
     return stn_name


### PR DESCRIPTION
- Fixes issue where current station has no data between start/end, and then is no longer present in stations dataframe, causing a KeyError.
- Fixes issue so stations dataframe is not filtered when start and end are None. 
- Fixes issue for getting stations with meteo_var=slice(None), list all stations that have at least one of all possible meteo_vars. (Before this change `hpd.io.knmi.get_station_name(739)` was not working).