### PR TITLE
General method for multiple observations at the same location

### DIFF
--- a/examples/05_bronhouderportaal_bro.ipynb
+++ b/examples/05_bronhouderportaal_bro.ipynb
@@ -1074,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1142,8 +1142,8 @@
    ],
    "source": [
     "lst_lowest_tube = []\n",
-    "for monitoring_well in oc.monitoring_well.unique():\n",
-    "    oc_mw = oc.loc[oc.monitoring_well == monitoring_well]\n",
+    "for location in oc.location.unique():\n",
+    "    oc_mw = oc.loc[oc.location == location]\n",
     "\n",
     "    lowest_screen_bottom_tube_nr = oc_mw.loc[\n",
     "        oc_mw.screen_bottom == oc_mw.screen_bottom.min(), \"tube_nr\"\n",
@@ -1154,17 +1154,17 @@
     "    ].values[0]\n",
     "\n",
     "    lst_lowest_tube.append(\n",
-    "        [monitoring_well, lowest_screen_bottom_tube_nr, lowest_screen_top_tube_nr]\n",
+    "        [location, lowest_screen_bottom_tube_nr, lowest_screen_top_tube_nr]\n",
     "    )\n",
     "\n",
     "df_lowest_tube = pd.DataFrame(\n",
     "    lst_lowest_tube,\n",
     "    columns=[\n",
-    "        \"monitoring_well\",\n",
+    "        \"location\",\n",
     "        \"lowest_screen_bottom_tube_nr\",\n",
     "        \"lowest_screen_top_tube_nr\",\n",
     "    ],\n",
-    ").set_index(\"monitoring_well\")\n",
+    ").set_index(\"location\")\n",
     "\n",
     "df_lowest_tube"
    ]
@@ -1189,7 +1189,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "dev",
    "language": "python",
    "name": "python3"
   },
@@ -1203,7 +1203,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/hydropandas/extensions/gwobs.py
+++ b/hydropandas/extensions/gwobs.py
@@ -329,16 +329,14 @@ class GwObsAccessor:
     def set_tube_nr(
         self, radius=1, xcol="x", ycol="y", if_exists="error", add_to_meta=False
     ):
-        """This method computes the tube numbers based on the location of the
-        observations.
+        """Set the tube numbers based on the location of the observations.
 
-        Then it sets the value of the tube number:
+        The value of the tube number is set:
 
-        - in the ObsCollection dataframe
-        - as the attribute of an Obs object
-        - in the meta dictionary of the Obs object (only if add_to_meta is
+        - In the ObsCollection dataframe
+        - As the attribute of an Obs object
+        - optionally: In the meta dictionary of the Obs object (only if add_to_meta is
           True)
-
 
         This method is useful for groundwater observations. If two or more
         observation points are close to each other they will be seen as one
@@ -408,7 +406,7 @@ class GwObsAccessor:
                             pb_dub, "tube_nr", i + 1, add_to_meta=add_to_meta
                         )
 
-    def set_tube_nr_monitoring_well(
+    def set_tube_nr_location(
         self,
         loc_col,
         radius=1,
@@ -417,32 +415,26 @@ class GwObsAccessor:
         if_exists="error",
         add_to_meta=False,
     ):
-        """This method sets the tube_nr and monitoring_well name of an observation
-        point based on the location of the observations.
+        """This method sets the tube_nr and location attributes of a GroundwaterObs
+        based on the location and screen depth of the observations.
 
-        When two or more tubes are close to another, as defined by radius,
-        they are set to the same `monitoring_well` and an increasing `tube_nr` based
-        on depth.
-
-        The value of the tube_nr and the monitoring_well are set:
-
+        The value of the tube_nr and the location are set:
         - in the ObsCollection dataframe
         - as the attribute of an Obs object
-        - in the meta dictionary of the Obs object (only if add_to_meta is
+        - optional: in the meta dictionary of the Obs object (only if add_to_meta is
           True)
 
-        This method is useful for groundwater observations. If two or more
-        observation points are close to each other they will be seen as one
-        monitoring_well with multiple tubes. The tube_nr is based on the
+        If two or more observations are close to each other they will be seen 
+        as one location with multiple tubes. The tube_nr is based on the
         'screen_bottom' attribute of the observations in such a way that
-        the deepest tube has the highest tube number. The monitoring_well is
-        based on the named of the loc_col of the screen with the lowest
+        the deepest tube has the highest tube number. The location name is
+        based on the name in the loc_col of the screen with the lowest
         tube_nr.
 
         Parameters
         ----------
         loc_col : str
-            the column name with the names to use for the monitoring_well
+            the column name with the names to use for the location
         radius : int, optional
             max distance between two observations to be seen as one location,
             by default 1
@@ -465,18 +457,18 @@ class GwObsAccessor:
         """
 
         # check if columns exists in obscollection
-        if "tube_nr" in self._obj.columns or "monitoring_well" in self._obj.columns:
+        if "tube_nr" in self._obj.columns or "location" in self._obj.columns:
             if if_exists == "error":
                 raise RuntimeError(
-                    "the column 'tube_nr or monitoring_well' already exist, set"
+                    "the column 'tube_nr or location' already exist, set"
                     "if_exists='replace' to replace the current values"
                 )
             elif if_exists == "replace":
                 self._obj["tube_nr"] = np.nan
-                self._obj["monitoring_well"] = np.nan
+                self._obj["location"] = np.nan
         else:
             self._obj["tube_nr"] = np.nan
-            self._obj["monitoring_well"] = np.nan
+            self._obj["location"] = np.nan
 
         # apply tube numbers to tubes that are close to eachother
         for name in self._obj.index:
@@ -491,25 +483,25 @@ class GwObsAccessor:
                     self._obj._set_metadata_value(
                         name, "tube_nr", 1, add_to_meta=add_to_meta
                     )
-                    monitoring_well = self._obj.loc[name, loc_col]
+                    location = self._obj.loc[name, loc_col]
                     self._obj._set_metadata_value(
                         name,
-                        "monitoring_well",
-                        monitoring_well,
+                        "location",
+                        location,
                         add_to_meta=add_to_meta,
                     )
                 else:
                     dup_x2 = dup_x.sort_values("screen_bottom", ascending=False)
                     for i, pb_dub in enumerate(dup_x2.index):
                         if i == 0:
-                            monitoring_well = self._obj.loc[pb_dub, loc_col]
+                            location = self._obj.loc[pb_dub, loc_col]
                         self._obj._set_metadata_value(
                             pb_dub, "tube_nr", i + 1, add_to_meta=add_to_meta
                         )
                         self._obj._set_metadata_value(
                             pb_dub,
-                            "monitoring_well",
-                            monitoring_well,
+                            "location",
+                            location,
                             add_to_meta=add_to_meta,
                         )
 

--- a/hydropandas/extensions/gwobs.py
+++ b/hydropandas/extensions/gwobs.py
@@ -424,7 +424,7 @@ class GwObsAccessor:
         - optional: in the meta dictionary of the Obs object (only if add_to_meta is
           True)
 
-        If two or more observations are close to each other they will be seen 
+        If two or more observations are close to each other they will be seen
         as one location with multiple tubes. The tube_nr is based on the
         'screen_bottom' attribute of the observations in such a way that
         the deepest tube has the highest tube number. The location name is

--- a/hydropandas/extensions/plots.py
+++ b/hydropandas/extensions/plots.py
@@ -80,9 +80,7 @@ class CollectionPlots:
 
         for name in plot_names:
             if per_location:
-                oc = self._obj.loc[
-                    self._obj.location == name, "obs"
-                ].sort_index()
+                oc = self._obj.loc[self._obj.location == name, "obs"].sort_index()
             else:
                 oc = self._obj.loc[[name], "obs"]
 
@@ -250,9 +248,7 @@ class CollectionPlots:
 
         for name in plot_names:
             if per_location:
-                oc = self._obj.loc[
-                    self._obj.location == name, "obs"
-                ].sort_index()
+                oc = self._obj.loc[self._obj.location == name, "obs"].sort_index()
                 o = oc.iloc[-1]
                 name = o.name
             else:

--- a/hydropandas/extensions/plots.py
+++ b/hydropandas/extensions/plots.py
@@ -29,7 +29,7 @@ class CollectionPlots:
         savedir="figures",
         tmin=None,
         tmax=None,
-        per_monitoring_well=True,
+        per_location=True,
         **kwargs,
     ):
         """Create interactive plots of the observations using bokeh.
@@ -42,8 +42,8 @@ class CollectionPlots:
             start date for timeseries plot
         tmax : dt.datetime, optional
             end date for timeseries plot
-        per_monitoring_well : bool, optional
-            if True plot multiple tubes at the same monitoring_well in one
+        per_location : bool, optional
+            if True plot multiple observations at the same location in one
             figure
         **kwargs :
             will be passed to the Obs.interactive_plot method, options
@@ -73,25 +73,15 @@ class CollectionPlots:
             "tan",
         )
 
-        # check if observations consist of monitoring wells
-        if per_monitoring_well:
-            otype = self._obj._infer_otype()
-            if isinstance(otype, (list, np.ndarray)):
-                per_monitoring_well = False
-            elif otype.__name__ == "GroundwaterObs":
-                pass
-            else:
-                per_monitoring_well = False
-
-        if per_monitoring_well:
-            plot_names = self._obj.groupby("monitoring_well").count().index
+        if per_location:
+            plot_names = self._obj.groupby("location").count().index
         else:
             plot_names = self._obj.index
 
         for name in plot_names:
-            if per_monitoring_well:
+            if per_location:
                 oc = self._obj.loc[
-                    self._obj.monitoring_well == name, "obs"
+                    self._obj.location == name, "obs"
                 ].sort_index()
             else:
                 oc = self._obj.loc[[name], "obs"]
@@ -123,7 +113,7 @@ class CollectionPlots:
         m=None,
         tiles="OpenStreetMap",
         fname=None,
-        per_monitoring_well=True,
+        per_location=True,
         color="blue",
         legend_name=None,
         add_legend=True,
@@ -146,7 +136,7 @@ class CollectionPlots:
           the last one should have add_legend = True to create a correct legend
         - the color of the observation point on the map is now the same color
           as the line of the observation measurements. Also a built-in color
-          cycle is used for different measurements at the same monitoring_well.
+          cycle is used for different measurements at the same location.
 
         Parameters
         ----------
@@ -158,8 +148,8 @@ class CollectionPlots:
             background tiles, default is openstreetmap
         fname : str, optional
             name of the folium map
-        per_monitoring_well : bool, optional
-            if True plot multiple tubes at the same monitoring well in one
+        per_location : bool, optional
+            if True plot multiple observations at the same location in one
             figure
         color : str, optional
             color of the observation points on the map
@@ -168,7 +158,7 @@ class CollectionPlots:
         add_legend : boolean, optional
             add a legend to a plot
         map_label : str, optional
-            add a label to the monitoring wells on the map, the label should be
+            add a label to the observations on the map, the label should be
             1. the attribute of an observation
             2. the key in the meta attribute of the observation
             3. a generic label for each observation in this collection.
@@ -224,7 +214,7 @@ class CollectionPlots:
         # create interactive bokeh plots
         if create_interactive_plots and not empty_obs:
             self._obj.plots.interactive_plots(
-                savedir=plot_dir, per_monitoring_well=per_monitoring_well, **kwargs
+                savedir=plot_dir, per_location=per_location, **kwargs
             )
 
         # check if observation collection has lat and lon values
@@ -253,25 +243,15 @@ class CollectionPlots:
         group_name = '<span style=\\"color: {};\\">{}</span>'.format(color, legend_name)
         group = folium.FeatureGroup(name=group_name)
 
-        # check if observations consist of monitoring wells
-        if per_monitoring_well:
-            otype = self._obj._infer_otype()
-            if isinstance(otype, (list, np.ndarray)):
-                per_monitoring_well = False
-            elif otype.__name__ == "GroundwaterObs":
-                pass
-            else:
-                per_monitoring_well = False
-
-        if per_monitoring_well:
-            plot_names = self._obj.groupby("monitoring_well").count().index
+        if per_location:
+            plot_names = self._obj.groupby("location").count().index
         else:
             plot_names = self._obj.index
 
         for name in plot_names:
-            if per_monitoring_well:
+            if per_location:
                 oc = self._obj.loc[
-                    self._obj.monitoring_well == name, "obs"
+                    self._obj.location == name, "obs"
                 ].sort_index()
                 o = oc.iloc[-1]
                 name = o.name
@@ -297,7 +277,7 @@ class CollectionPlots:
                 ).add_to(group)
 
                 if map_label != "":
-                    if map_label in o._metadata:
+                    if map_label in o._get_meta_attr():
                         map_label_val = getattr(o, map_label)
                     elif map_label in o.meta.keys():
                         map_label_val = o.meta[map_label]

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -294,11 +294,11 @@ def measurements_from_gld(
     gld = glds[0]
 
     meta = {"source": "BRO"}
-    meta["monitoring_well"] = gld.find("ns11:monitoringPoint//gldcommon:broId", ns).text
+    meta["location"] = gld.find("ns11:monitoringPoint//gldcommon:broId", ns).text
     meta["tube_nr"] = int(
         gld.find("ns11:monitoringPoint//gldcommon:tubeNumber", ns).text
     )
-    meta["name"] = f"{meta['monitoring_well']}_{meta['tube_nr']}"
+    meta["name"] = f"{meta['location']}_{meta['tube_nr']}"
     gmn = gld.find("ns11:groundwaterMonitoringNet//gldcommon:broId", ns)
     if gmn is None:
         meta["monitoringsnet"] = None
@@ -340,7 +340,7 @@ def measurements_from_gld(
     df = df.loc[tmin:tmax]
 
     # add metadata from gmw
-    meta.update(get_metadata_from_gmw(meta["monitoring_well"], meta["tube_nr"]))
+    meta.update(get_metadata_from_gmw(meta["location"], meta["tube_nr"]))
 
     return df, meta
 
@@ -382,7 +382,7 @@ def get_full_metadata_from_gmw(bro_id, tube_nr):
     if len(gmws) != 1:
         raise (Exception("Only one gmw supported"))
     gmw = gmws[0]
-    meta = {"monitoring_well": bro_id, "tube_nr": tube_nr, "source": "BRO"}
+    meta = {"location": bro_id, "tube_nr": tube_nr, "source": "BRO"}
     for child in gmw:
         key = child.tag.split("}", 1)[1]
         if len(child) == 0:
@@ -555,7 +555,7 @@ def get_metadata_from_gmw(bro_id, tube_nr):
 
     gmw = _get_gmw_from_bro_id(bro_id)
 
-    meta = {"monitoring_well": bro_id, "tube_nr": tube_nr, "source": "BRO"}
+    meta = {"location": bro_id, "tube_nr": tube_nr, "source": "BRO"}
 
     # x and y
     xy_elem = gmw.find("dsgmw:deliveredLocation//gmwcommon:location//gml:pos", ns)

--- a/hydropandas/io/bronhouderportaal_bro.py
+++ b/hydropandas/io/bronhouderportaal_bro.py
@@ -174,7 +174,7 @@ def get_metadata_from_gmw(path_xml, tube_nr, full_meta=False):
     else:
         name = path_xml.stem  # filname without extention
     meta["name"] = f"{name}-{tube_nr}"
-    meta["monitoring_well"] = name
+    meta["location"] = name
 
     if full_meta:
         if tree.find("brocommon:deliveryAccountableParty", ns) is not None:

--- a/hydropandas/io/dino.py
+++ b/hydropandas/io/dino.py
@@ -90,7 +90,7 @@ def _read_dino_groundwater_metadata(f, line):
             meta_tsi = {}
             start_date = pd.to_datetime(meta.pop("startdatum"), dayfirst=True)
             # end_date = pd.to_datetime(meta.pop('einddatum'), dayfirst=True)
-            meta_tsi["monitoring_well"] = meta["locatie"]
+            meta_tsi["location"] = meta["locatie"]
             for key, item in _translate_dic_float.items():
                 if meta[key] == "":
                     meta_tsi[item] = np.nan
@@ -111,7 +111,7 @@ def _read_dino_groundwater_metadata(f, line):
 
         # remove series with non time variant metadata from meta_ts
         ts_keys = (
-            ["monitoring_well"]
+            ["location"]
             + list(_translate_dic_float.values())
             + list(_translate_dic_div_100.values())
         )
@@ -121,12 +121,12 @@ def _read_dino_groundwater_metadata(f, line):
                 meta_ts.pop(key)
 
         obs_att = meta_tsi.copy()
-        obs_att["name"] = f"{obs_att['monitoring_well']}-{int(obs_att['tube_nr']):03d}"
+        obs_att["name"] = f"{obs_att['location']}-{int(obs_att['tube_nr']):03d}"
         obs_att["metadata_available"] = True
     else:
         # no metadata
         obs_att = {}
-        obs_att["monitoring_well"] = ""
+        obs_att["location"] = ""
         obs_att["tube_nr"] = np.nan
         obs_att["name"] = "unknown"
         obs_att["x"] = np.nan
@@ -261,7 +261,7 @@ def read_dino_groundwater_quality_txt(f: Union[str, Path, FileIO]):
     meta = {
         "filename": fname,
         "source": "dino",
-        "monitoring_well": locatie["NITG-nr"],
+        "location": locatie["NITG-nr"],
         "name": locatie["NITG-nr"],
         "x": locatie["X-coord"],
         "y": locatie["Y-coord"],
@@ -385,9 +385,9 @@ def _read_artdino_groundwater_metadata(f, line):
 
     meta = {}
     if metalist:
-        meta["monitoring_well"] = metalist[-1]["locatie"]
+        meta["location"] = metalist[-1]["locatie"]
         meta["tube_nr"] = int(float(metalist[-1]["filternummer"]))
-        meta["name"] = "-".join([meta["monitoring_well"], metalist[-1]["filternummer"]])
+        meta["name"] = "-".join([meta["location"], metalist[-1]["filternummer"]])
         meta["x"] = float(metalist[-1]["x-coordinaat"])
         meta["y"] = float(metalist[-1]["y-coordinaat"])
         meetpunt = metalist[-1]["meetpunt nap"]
@@ -413,7 +413,7 @@ def _read_artdino_groundwater_metadata(f, line):
         meta["metadata_available"] = True
     else:
         # no metadata
-        meta["monitoring_well"] = ""
+        meta["location"] = ""
         meta["tube_nr"] = np.nan
         meta["name"] = "unknown"
         meta["x"] = np.nan
@@ -629,7 +629,7 @@ def _read_dino_waterlvl_metadata(f, line):
             elif key == "Y-coordinaat":
                 meta["y"] = float(value)
         elif key == "Locatie":
-            meta["monitoring_well"] = value
+            meta["location"] = value
             meta["name"] = value
 
     return meta

--- a/hydropandas/io/fews.py
+++ b/hydropandas/io/fews.py
@@ -38,7 +38,7 @@ def read_xml_fname(
         class of the observations, e.g. GroundwaterObs or WaterlvlObs
     translate_dic : dic or None, optional
         translate names from fews. If None this default dictionary is used:
-        {'locationId': 'monitoring_well'}.
+        {'locationId': 'location'}.
     low_memory : bool, optional
         whether to use xml-parsing method with lower memory footprint,
         default is True
@@ -70,7 +70,7 @@ def read_xml_fname(
         list of timeseries stored in ObsClass objects
     """
     if translate_dic is None:
-        translate_dic = {"locationId": "monitoring_well"}
+        translate_dic = {"locationId": "location"}
 
     if low_memory is True:
         obs_list = iterparse_pi_xml(
@@ -119,7 +119,7 @@ def iterparse_pi_xml(
         class of the observations, e.g. GroundwaterObs or WaterlvlObs
     translate_dic : dic or None, optional
         translate names from fews. If None this default dictionary is used:
-        {'locationId': 'monitoring_well'}.
+        {'locationId': 'location'}.
     locationIds : tuple or list of str, optional
         list of locationId's to read from XML file, others are skipped.
         If None (default) all locations are read.
@@ -150,7 +150,7 @@ def iterparse_pi_xml(
     from lxml.etree import iterparse
 
     if translate_dic is None:
-        translate_dic = {"locationId": "monitoring_well"}
+        translate_dic = {"locationId": "location"}
 
     tags = ["{{http://www.wldelft.nl/fews/PI}}{}".format(tag) for tag in tags]
 
@@ -295,7 +295,7 @@ def read_xmlstring(
         class of the observations, e.g. GroundwaterObs or WaterlvlObs
     translate_dic : dic or None, optional
         translate names from fews. If None this default dictionary is used:
-        {'locationId': 'monitoring_well'}.
+        {'locationId': 'location'}.
     locationIds : tuple or list of str, optional
         list of locationId's to read from XML file, others are skipped.
         If None (default) all locations are read.
@@ -312,7 +312,7 @@ def read_xmlstring(
         list of timeseries stored in ObsClass objects
     """
     if translate_dic is None:
-        translate_dic = {"locationId": "monitoring_well"}
+        translate_dic = {"locationId": "location"}
 
     if low_memory:
         obs_list = iterparse_pi_xml(
@@ -352,7 +352,7 @@ def read_xml_root(
         class of the observations, e.g. GroundwaterObs or WaterlvlObs
     translate_dic : dic or None, optional
         translate names from fews. If None this default dictionary is used:
-        {'locationId': 'monitoring_well'}.
+        {'locationId': 'location'}.
     locationIds : tuple or list of str, optional
         list of locationId's to read from XML file, others are skipped.
         If None (default) all locations are read.
@@ -366,7 +366,7 @@ def read_xml_root(
         list of timeseries stored in ObsClass objects
     """
     if translate_dic is None:
-        translate_dic = {"locationId": "monitoring_well"}
+        translate_dic = {"locationId": "location"}
 
     obs_list = []
     for item in root:
@@ -405,7 +405,7 @@ def read_xml_root(
 
             o, header = _obs_from_meta(ts, header, translate_dic, ObsClass)
             if locationIds is not None:
-                if header["monitoring_well"] in locationIds:
+                if header["location"] in locationIds:
                     obs_list.append(o)
             else:
                 obs_list.append(o)
@@ -463,9 +463,9 @@ def _obs_from_meta(
 
     if "parameterId" in header:
         parid = header["parameterId"]
-        name = header["monitoring_well"] + "_" + parid
+        name = header["location"] + "_" + parid
     else:
-        name = header["monitoring_well"]
+        name = header["location"]
 
     if isinstance(ObsClass, dict):
         if parid in ObsClass.keys():
@@ -483,7 +483,7 @@ def _obs_from_meta(
             unit=unit,
             meta=header,
             name=name,
-            monitoring_well=header["monitoring_well"],
+            location=header["location"],
             metadata_available=metadata_available,
             source="FEWS",
         )
@@ -500,7 +500,7 @@ def _obs_from_meta(
             unit=unit,
             meta=header,
             name=name,
-            monitoring_well=header["monitoring_well"],
+            location=header["location"],
             metadata_available=metadata_available,
             source="FEWS",
         )
@@ -650,7 +650,7 @@ def read_xml_filelist(
         If None (default) all locations are read.
     translate_dic : dic or None, optional
         translate names from fews. If None this default dictionary is used:
-        {'locationId': 'monitoring_well'}.
+        {'locationId': 'location'}.
     filterdict : dict, optional
         dictionary with tag name to apply filter to as keys, and list of
         accepted names as dictionary values to keep in final result,
@@ -668,7 +668,7 @@ def read_xml_filelist(
         list of timeseries stored in ObsClass objects
     """
     if translate_dic is None:
-        translate_dic = {"locationId": "monitoring_well"}
+        translate_dic = {"locationId": "location"}
 
     obs_list = []
     nfiles = len(fnames)

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -198,6 +198,7 @@ def get_knmi_timeseries_fname(
             "x": stations.loc[stn, "x"],
             "y": stations.loc[stn, "y"],
             "name": f"{meteo_var}_{stn_name}",
+            "location": stn_name,
             "source": "KNMI",
             "filename": fname,
         }
@@ -362,6 +363,7 @@ def get_knmi_timeseries_stn(
                 "y": y,
                 "station": stn,
                 "name": f"{meteo_var}_{stn_name}",
+                "location": stn_name,
                 "source": "KNMI",
             }
         )
@@ -679,6 +681,7 @@ def fill_missing_measurements(
             "y": stations.loc[stn, "y"],
             "station": stn,
             "name": f"{meteo_var}_{stn_name}",
+            "location": stn_name,
             "source": "KNMI",
         }
     )
@@ -1881,6 +1884,7 @@ def get_evaporation(
 
     stn_name = get_station_name(meta["station"], stations=get_stations(meteo_var))
     meta["name"] = f"{meteo_var}_{stn_name}"
+    meta["location"] = stn_name
     meta["unit"] = "m"
 
     return et, meta

--- a/hydropandas/io/lizard.py
+++ b/hydropandas/io/lizard.py
@@ -236,7 +236,7 @@ def get_metadata_tube(metadata_mw, tube_nr):
         tube_nr = 1
 
     metadata = {
-        "monitoring_well": metadata_mw["name"],
+        "location": metadata_mw["name"],
         "ground_level": metadata_mw["surface_level"],
         "source": "lizard",
         "unit": "m NAP",

--- a/hydropandas/io/menyanthes.py
+++ b/hydropandas/io/menyanthes.py
@@ -85,7 +85,7 @@ def read_file(path, ObsClass, load_oseries=True, load_stresses=True):
             "y",
             "source",
             "unit",
-            "monitoring_well",
+            "location",
             "tube_nr",
             "metadata_available",
             "ground_level",
@@ -96,7 +96,7 @@ def read_file(path, ObsClass, load_oseries=True, load_stresses=True):
         unit = "m NAP"
     elif ObsClass == WaterlvlObs:
         _rename_dic = {"xcoord": "x", "ycoord": "y", "measpointlev": "tube_top"}
-        _keys_o = ["name", "x", "y", "source", "unit", "monitoring_well"]
+        _keys_o = ["name", "x", "y", "source", "unit", "location"]
         unit = "m NAP"
     else:
         _rename_dic = {

--- a/hydropandas/io/pastas.py
+++ b/hydropandas/io/pastas.py
@@ -30,7 +30,7 @@ def _get_metadata_from_obs(o):
         meta dictionary.
     """
     meta = dict()
-    for attr_key in o._metadata:
+    for attr_key in o._get_meta_attr():
         val = getattr(o, attr_key)
         if isinstance(val, (int, float, str, bool)):
             meta[attr_key] = val

--- a/hydropandas/io/solinst.py
+++ b/hydropandas/io/solinst.py
@@ -131,7 +131,7 @@ def read_solinst_file(
     meta["filename"] = f
     meta["source"] = meta["Created_by"]
     meta["name"] = name
-    meta['location'] = name
+    meta["location"] = name
     meta["unit"] = series_ch1_data_header.Unit.lower()
     meta["metadata_available"] = True
 

--- a/hydropandas/io/solinst.py
+++ b/hydropandas/io/solinst.py
@@ -131,7 +131,7 @@ def read_solinst_file(
     meta["filename"] = f
     meta["source"] = meta["Created_by"]
     meta["name"] = name
-    meta["monitoring_well"] = name
+    meta['location'] = name
     meta["unit"] = series_ch1_data_header.Unit.lower()
     meta["metadata_available"] = True
 

--- a/hydropandas/io/wiski.py
+++ b/hydropandas/io/wiski.py
@@ -138,7 +138,7 @@ def read_wiski_file(
         metadata = {"source": "wiski", "unit": unit}
         for key, val in header.items():
             if key == "Station Site":
-                metadata["monitoring_well"] = val
+                metadata["location"] = val
             elif key == "x":
                 metadata["x"] = val
             elif key == "y":

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1428,9 +1428,7 @@ class ObsCollection(pd.DataFrame):
             obsclass = getattr(obs, row["obs"])
             # get observation specific metadata
             metadata = {
-                k: v
-                for (k, v) in all_metadata.items()
-                if k in obsclass._metadata
+                k: v for (k, v) in all_metadata.items() if k in obsclass._metadata
             }
             metadata["name"] = oname
 

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1428,7 +1428,9 @@ class ObsCollection(pd.DataFrame):
             obsclass = getattr(obs, row["obs"])
             # get observation specific metadata
             metadata = {
-                k: v for (k, v) in all_metadata.items() if k in obsclass._get_meta_attr()
+                k: v
+                for (k, v) in all_metadata.items()
+                if k in obsclass._get_meta_attr()
             }
             metadata["name"] = oname
 
@@ -2388,7 +2390,9 @@ class ObsCollection(pd.DataFrame):
 
         # add all metadata that is equal for all observations
         kwargs = {}
-        meta_att = set(otype._get_meta_attr()) - set(["x", "y", "name", "source", "meta"])
+        meta_att = set(otype._get_meta_attr()) - set(
+            ["x", "y", "name", "source", "meta"]
+        )
         for att in meta_att:
             if (self.loc[:, att] == self.iloc[0].loc[att]).all():
                 kwargs[att] = self.iloc[0].loc[att]

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1430,7 +1430,7 @@ class ObsCollection(pd.DataFrame):
             metadata = {
                 k: v
                 for (k, v) in all_metadata.items()
-                if k in obsclass._get_meta_attr()
+                if k in obsclass._metadata
             }
             metadata["name"] = oname
 
@@ -2390,8 +2390,8 @@ class ObsCollection(pd.DataFrame):
 
         # add all metadata that is equal for all observations
         kwargs = {}
-        meta_att = set(otype._get_meta_attr()) - set(
-            ["x", "y", "name", "source", "meta"]
+        meta_att = set(otype._metadata) - set(
+            ["x", "y", "location", "monitoring_well", "name", "source", "meta"]
         )
         for att in meta_att:
             if (self.loc[:, att] == self.iloc[0].loc[att]).all():

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -941,7 +941,7 @@ class ObsCollection(pd.DataFrame):
             raise ValueError(f"{iname}  not in index")
 
         o = self.loc[iname, "obs"]
-        if att_name in o._metadata:
+        if att_name in o._get_meta_attr():
             setattr(o, att_name, value)
             logger.debug(f"set attribute {att_name} of {iname} to {value}")
 
@@ -996,7 +996,7 @@ class ObsCollection(pd.DataFrame):
         # check oc data with individual object attributes
         if check_individual_obs:
             for o in self.obs.values:
-                for att in o._metadata:
+                for att in o._get_meta_attr():
                     if att not in ["name", "meta"]:
                         v1 = self.loc[o.name, att]
                         v2 = getattr(o, att)
@@ -1428,7 +1428,7 @@ class ObsCollection(pd.DataFrame):
             obsclass = getattr(obs, row["obs"])
             # get observation specific metadata
             metadata = {
-                k: v for (k, v) in all_metadata.items() if k in obsclass._metadata
+                k: v for (k, v) in all_metadata.items() if k in obsclass._get_meta_attr()
             }
             metadata["name"] = oname
 
@@ -1645,7 +1645,7 @@ class ObsCollection(pd.DataFrame):
         from .io.fews import read_xml_filelist, read_xmlstring
 
         if translate_dic is None:
-            translate_dic = {"locationId": "monitoring_well"}
+            translate_dic = {"locationId": "location"}
 
         meta = {"type": ObsClass}
 
@@ -2388,7 +2388,7 @@ class ObsCollection(pd.DataFrame):
 
         # add all metadata that is equal for all observations
         kwargs = {}
-        meta_att = set(otype._metadata) - set(["x", "y", "name", "source", "meta"])
+        meta_att = set(otype._get_meta_attr()) - set(["x", "y", "name", "source", "meta"])
         for att in meta_att:
             if (self.loc[:, att] == self.iloc[0].loc[att]).all():
                 kwargs[att] = self.iloc[0].loc[att]

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -71,9 +71,10 @@ class Obs(pd.DataFrame):
         the attributes listed in _metadata or keyword arguments for the constructor of a
         pandas.DataFrame.
         """
+        # print(self._metadata)
         if (len(args) > 0) and isinstance(args[0], Obs):
-            for key in args[0]._metadata:
-                if (key in self._metadata) and (key not in kwargs):
+            for key in args[0]._get_meta_attr():
+                if (key in Obs._metadata) and (key not in kwargs):
                     kwargs[key] = getattr(args[0], key)
 
         self.name = kwargs.pop("name", "")
@@ -85,6 +86,7 @@ class Obs(pd.DataFrame):
         self.source = kwargs.pop("source", "")
         self.unit = kwargs.pop("unit", "")
 
+        print(kwargs)
         super(Obs, self).__init__(*args, **kwargs)
 
     def __repr__(self) -> str:
@@ -558,8 +560,8 @@ class GroundwaterObs(Obs):
         """
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in GroundwaterObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in GroundwaterObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)
@@ -572,7 +574,7 @@ class GroundwaterObs(Obs):
         self.screen_top = kwargs.pop("screen_top", np.nan)
         self.screen_bottom = kwargs.pop("screen_bottom", np.nan)
         self.metadata_available = kwargs.pop("metadata_available", np.nan)
-
+        print(kwargs)
         super().__init__(*args, **kwargs)
 
     @property
@@ -938,8 +940,8 @@ class WaterQualityObs(Obs):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in WaterQualityObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in WaterQualityObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)
@@ -996,8 +998,8 @@ class WaterlvlObs(Obs):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in WaterlvlObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in WaterlvlObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)
@@ -1077,8 +1079,8 @@ class ModelObs(Obs):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in ModelObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in ModelObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)
@@ -1103,8 +1105,8 @@ class MeteoObs(Obs):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in MeteoObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in MeteoObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)
@@ -1266,8 +1268,8 @@ class EvaporationObs(MeteoObs):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in EvaporationObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in EvaporationObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)
@@ -1359,8 +1361,8 @@ class PrecipitationObs(MeteoObs):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
-                for key in args[0]._metadata:
-                    if (key in PrecipitationObs._get_meta_attr()) and (
+                for key in args[0]._get_meta_attr():
+                    if (key in PrecipitationObs._metadata) and (
                         key not in kwargs.keys()
                     ):
                         kwargs[key] = getattr(args[0], key)

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -186,7 +186,7 @@ class Obs(pd.DataFrame):
         return Obs
 
     def _get_meta_attr(self, ignore=("monitoring_well",)):
-        """Get metadata attributes excluding the ones in the ignore_list.
+        """Get metadata attributes excluding the ones in ignore.
 
         Parameters
         ----------
@@ -199,7 +199,7 @@ class Obs(pd.DataFrame):
             list of metadata attributes
         """
 
-        return [a for a in self._metadata if a not in ignore_list]
+        return [a for a in self._metadata if a not in ignore]
 
     def _get_first_numeric_col_name(self):
         """Get the first numeric column name of the observations.

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -73,7 +73,7 @@ class Obs(pd.DataFrame):
         """
         if (len(args) > 0) and isinstance(args[0], Obs):
             for key in args[0]._metadata:
-                if (key in _metadata) and (key not in kwargs):
+                if (key in self._metadata) and (key not in kwargs):
                     kwargs[key] = getattr(args[0], key)
 
         self.name = kwargs.pop("name", "")

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -73,7 +73,7 @@ class Obs(pd.DataFrame):
         """
         if (len(args) > 0) and isinstance(args[0], Obs):
             for key in args[0]._metadata:
-                if (key in Obs._get_meta_attr()) and (key not in kwargs):
+                if (key in _metadata) and (key not in kwargs):
                     kwargs[key] = getattr(args[0], key)
 
         self.name = kwargs.pop("name", "")

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -561,9 +561,7 @@ class GroundwaterObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._get_meta_attr():
-                    if (key in GroundwaterObs._metadata) and (
-                        key not in kwargs.keys()
-                    ):
+                    if (key in GroundwaterObs._metadata) and (key not in kwargs.keys()):
                         kwargs[key] = getattr(args[0], key)
 
         if "monitoring_well" in kwargs:
@@ -999,9 +997,7 @@ class WaterlvlObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._get_meta_attr():
-                    if (key in WaterlvlObs._metadata) and (
-                        key not in kwargs.keys()
-                    ):
+                    if (key in WaterlvlObs._metadata) and (key not in kwargs.keys()):
                         kwargs[key] = getattr(args[0], key)
 
         if "monitoring_well" in kwargs:
@@ -1080,9 +1076,7 @@ class ModelObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._get_meta_attr():
-                    if (key in ModelObs._metadata) and (
-                        key not in kwargs.keys()
-                    ):
+                    if (key in ModelObs._metadata) and (key not in kwargs.keys()):
                         kwargs[key] = getattr(args[0], key)
 
         self.model = kwargs.pop("model", "")
@@ -1106,9 +1100,7 @@ class MeteoObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._get_meta_attr():
-                    if (key in MeteoObs._metadata) and (
-                        key not in kwargs.keys()
-                    ):
+                    if (key in MeteoObs._metadata) and (key not in kwargs.keys()):
                         kwargs[key] = getattr(args[0], key)
 
         self.station = kwargs.pop("station", np.nan)
@@ -1269,9 +1261,7 @@ class EvaporationObs(MeteoObs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._get_meta_attr():
-                    if (key in EvaporationObs._metadata) and (
-                        key not in kwargs.keys()
-                    ):
+                    if (key in EvaporationObs._metadata) and (key not in kwargs.keys()):
                         kwargs[key] = getattr(args[0], key)
 
         super().__init__(*args, **kwargs)

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -185,21 +185,21 @@ class Obs(pd.DataFrame):
     def _constructor(self):
         return Obs
 
-    def _get_meta_attr(self, ignore_list =['monitoring_well']):
+    def _get_meta_attr(self, ignore=("monitoring_well",)):
         """Get metadata attributes excluding the ones in the ignore_list.
 
         Parameters
         ----------
-        ignore_list : list, optional
-            list of attributes to ignore, by default ['monitoring_well']
-        
+        ignore : tuple, optional
+            attributes to ignore, by default ('monitoring_well',)
+
         Returns
         -------
         list
             list of metadata attributes
         """
 
-        return [a for a in self._metadata if not a in ignore_list]
+        return [a for a in self._metadata if a not in ignore_list]
 
     def _get_first_numeric_col_name(self):
         """Get the first numeric column name of the observations.
@@ -215,9 +215,8 @@ class Obs(pd.DataFrame):
         for col in self.columns:
             if is_numeric_dtype(self[col]):
                 return col
-        
-        return None
 
+        return None
 
     def copy(self, deep=True):
         """Create a copy of the observation.
@@ -530,7 +529,7 @@ class GroundwaterObs(Obs):
     - tube_top: top of the tube in m above date (NAP)
     - metadata_available: boolean indicating if metadata is available for
       the measurement point.
-    
+
     Note
     ----
     In hydropandas version 0.13.0 the 'monitoring_well' attribute was removed and
@@ -545,7 +544,7 @@ class GroundwaterObs(Obs):
         "ground_level",
         "tube_top",
         "metadata_available",
-        "monitoring_well"
+        "monitoring_well",
     ]
 
     def __init__(self, *args, **kwargs):
@@ -560,10 +559,12 @@ class GroundwaterObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._metadata:
-                    if (key in GroundwaterObs._get_meta_attr()) and (key not in kwargs.keys()):
+                    if (key in GroundwaterObs._get_meta_attr()) and (
+                        key not in kwargs.keys()
+                    ):
                         kwargs[key] = getattr(args[0], key)
 
-        if 'monitoring_well' in kwargs:
+        if "monitoring_well" in kwargs:
             self.monitoring_well = kwargs.pop("monitoring_well", "")
         self.tube_nr = kwargs.pop("tube_nr", "")
         self.ground_level = kwargs.pop("ground_level", np.nan)
@@ -711,7 +712,7 @@ class GroundwaterObs(Obs):
             name=meta.pop("name"),
             x=meta.pop("x"),
             y=meta.pop("y"),
-            location=meta.pop('location'),
+            location=meta.pop("location"),
             source=meta.pop("source"),
             unit=meta.pop("unit"),
             screen_bottom=meta.pop("screen_bottom"),
@@ -761,7 +762,7 @@ class GroundwaterObs(Obs):
             name=meta.pop("name"),
             x=meta.pop("x"),
             y=meta.pop("y"),
-            location=meta.pop('location'),
+            location=meta.pop("location"),
             filename=meta.pop("filename"),
             source=meta.pop("source"),
             unit=meta.pop("unit"),
@@ -908,7 +909,7 @@ class GroundwaterObs(Obs):
             name=meta.pop("name"),
             x=meta.pop("x"),
             y=meta.pop("y"),
-            location=meta.pop('location'),
+            location=meta.pop("location"),
             filename=meta.pop("filename"),
             source=meta.pop("source"),
             unit=meta.pop("unit"),
@@ -931,7 +932,7 @@ class WaterQualityObs(Obs):
         "tube_nr",
         "ground_level",
         "metadata_available",
-        "monitoring_well"
+        "monitoring_well",
     ]
 
     def __init__(self, *args, **kwargs):
@@ -943,7 +944,7 @@ class WaterQualityObs(Obs):
                     ):
                         kwargs[key] = getattr(args[0], key)
 
-        if 'monitoring_well' in kwargs:
+        if "monitoring_well" in kwargs:
             self.monitoring_well = kwargs.pop("monitoring_well", "")
         self.tube_nr = kwargs.pop("tube_nr", "")
         self.ground_level = kwargs.pop("ground_level", np.nan)
@@ -996,10 +997,12 @@ class WaterlvlObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._metadata:
-                    if (key in WaterlvlObs._get_meta_attr()) and (key not in kwargs.keys()):
+                    if (key in WaterlvlObs._get_meta_attr()) and (
+                        key not in kwargs.keys()
+                    ):
                         kwargs[key] = getattr(args[0], key)
 
-        if 'monitoring_well' in kwargs:
+        if "monitoring_well" in kwargs:
             self.monitoring_well = kwargs.pop("monitoring_well", "")
         self.metadata_available = kwargs.pop("metadata_available", np.nan)
 
@@ -1075,7 +1078,9 @@ class ModelObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._metadata:
-                    if (key in ModelObs._get_meta_attr()) and (key not in kwargs.keys()):
+                    if (key in ModelObs._get_meta_attr()) and (
+                        key not in kwargs.keys()
+                    ):
                         kwargs[key] = getattr(args[0], key)
 
         self.model = kwargs.pop("model", "")
@@ -1099,7 +1104,9 @@ class MeteoObs(Obs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._metadata:
-                    if (key in MeteoObs._get_meta_attr()) and (key not in kwargs.keys()):
+                    if (key in MeteoObs._get_meta_attr()) and (
+                        key not in kwargs.keys()
+                    ):
                         kwargs[key] = getattr(args[0], key)
 
         self.station = kwargs.pop("station", np.nan)
@@ -1260,7 +1267,9 @@ class EvaporationObs(MeteoObs):
         if len(args) > 0:
             if isinstance(args[0], Obs):
                 for key in args[0]._metadata:
-                    if (key in EvaporationObs._get_meta_attr()) and (key not in kwargs.keys()):
+                    if (key in EvaporationObs._get_meta_attr()) and (
+                        key not in kwargs.keys()
+                    ):
                         kwargs[key] = getattr(args[0], key)
 
         super().__init__(*args, **kwargs)

--- a/tests/test_002_obs_objects.py
+++ b/tests/test_002_obs_objects.py
@@ -16,7 +16,7 @@ def _get_groundwater_obs(name="groundwaterobs_001", tube_nr=2):
     o = hpd.GroundwaterObs(
         df,
         name=name,
-        monitoring_well=name.split("_")[0],
+        location=name.split("_")[0],
         x=x,
         y=y,
         source="generated",
@@ -43,7 +43,7 @@ def _get_waterlvl_obs():
     o = hpd.WaterlvlObs(
         df,
         name="waterlvl_obs1",
-        monitoring_well="obs1",
+        location="obs1",
         x=x,
         y=y,
         filename="",
@@ -69,7 +69,7 @@ def test_groundwater_quality_obs():
     hpd.WaterlvlObs(
         df,
         name="waterquality_obs1",
-        monitoring_well="waterquality",
+        location="waterquality",
         x=3,
         y=4,
         filename="",
@@ -123,14 +123,14 @@ def test_convert_waterlvl_groundwater_obs():
         x=54.37326,
         y=-5.57900,
         source="my fantasy",
-        monitoring_well="Weirwood tree",
+        location="Weirwood tree",
         meta={"place": "Winterfell"},
     )
 
     # This is what I want to do, but now I will lose all metadata
     o_gw = hpd.GroundwaterObs(o_wl, ground_level=200)
 
-    assert o_wl.monitoring_well == o_gw.monitoring_well, "conversion failed"
+    assert o_wl.location == o_gw.location, "conversion failed"
     assert o_gw.ground_level == 200, "conversion failed"
 
 
@@ -218,14 +218,14 @@ def test_get_obs():
     assert o.name == "groundwaterobs_001"
 
     # by attributes
-    o = oc.get_obs(monitoring_well="groundwaterobs", tube_nr=2)
+    o = oc.get_obs(location="groundwaterobs", tube_nr=2)
     assert isinstance(o, hpd.GroundwaterObs)
     assert o.tube_nr == 2
 
     # multiple observations
     with pytest.raises(ValueError):
-        oc.get_obs(monitoring_well="groundwaterobs")
+        oc.get_obs(location="groundwaterobs")
 
     # no observations
     with pytest.raises(ValueError):
-        oc.get_obs(monitoring_well="I do not exist")
+        oc.get_obs(location="I do not exist")

--- a/tests/test_004_gwobs.py
+++ b/tests/test_004_gwobs.py
@@ -7,10 +7,10 @@ def test_set_tube_nr():
     dino_gw.gwobs.set_tube_nr(if_exists="replace")
 
 
-def test_set_tube_nr_monitoring_well():
+def test_set_tube_nr_location():
     fews_gw_prod = ttf.obscollection_fews_lowmemory()
-    fews_gw_prod.gwobs.set_tube_nr_monitoring_well(
-        "monitoring_well", if_exists="replace"
+    fews_gw_prod.gwobs.set_tube_nr_location(
+        "location", if_exists="replace"
     )
 
 

--- a/tests/test_004_gwobs.py
+++ b/tests/test_004_gwobs.py
@@ -9,9 +9,7 @@ def test_set_tube_nr():
 
 def test_set_tube_nr_location():
     fews_gw_prod = ttf.obscollection_fews_lowmemory()
-    fews_gw_prod.gwobs.set_tube_nr_location(
-        "location", if_exists="replace"
-    )
+    fews_gw_prod.gwobs.set_tube_nr_location("location", if_exists="replace")
 
 
 def test_get_modellayers_mf2005():

--- a/tests/test_008_visualisation.py
+++ b/tests/test_008_visualisation.py
@@ -64,8 +64,8 @@ def test_obscollection_to_imap():
     fews_gw_prod["lat"] = fews_gw_prod["lat"].astype(float)
     fews_gw_prod["lon"] = fews_gw_prod["lon"].astype(float)
 
-    fews_gw_prod.gwobs.set_tube_nr_monitoring_well(
-        "monitoring_well", if_exists="replace"
+    fews_gw_prod.gwobs.set_tube_nr_location(
+        "location", if_exists="replace"
     )
 
     fews_gw_prod.plots.interactive_map(

--- a/tests/test_008_visualisation.py
+++ b/tests/test_008_visualisation.py
@@ -64,9 +64,7 @@ def test_obscollection_to_imap():
     fews_gw_prod["lat"] = fews_gw_prod["lat"].astype(float)
     fews_gw_prod["lon"] = fews_gw_prod["lon"].astype(float)
 
-    fews_gw_prod.gwobs.set_tube_nr_location(
-        "location", if_exists="replace"
-    )
+    fews_gw_prod.gwobs.set_tube_nr_location("location", if_exists="replace")
 
     fews_gw_prod.plots.interactive_map(
         plot_dir,


### PR DESCRIPTION
This PR add the 'location' attribute to any Observation type. The value should be a label corresponding to a certain location. This should make it easier to group different observations at the same location. Two examples:
1. When you have a precipitation and an evaporation time series from meteostation 'de Bilt'. Both time series will be unique observation objects with the same 'location' attribute: 'de Bilt'. This is particularly useful when you want to plot all observation points on a map and want to add some logic for multiple observations at a single location.
2. When you have multiple tubes at the same monitoring well, every tube will have a unique time series and a unique observation object but the 'location' of the tube will be the same. This logic already existed under the 'monitoring_well' attribute, now this attribute is deprecated in favor of the 'location' attribute.