### PR TITLE
Add waterinfo via ddlpy

### DIFF
--- a/examples/08_waterinfo.ipynb
+++ b/examples/08_waterinfo.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reading waterinfo observations\n",
+    "\n",
+    "This notebook introduces how to use the `hydropandas` package to read, process and visualise data from the Waterinfo database. In this notebook the `ddlpy` package is used to access the waterinfo api. This package can be installed using `pip install ddlpy`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import geopandas as gpd\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import nlmod\n",
+    "import datetime as dt\n",
+    "import hydropandas as hpd\n",
+    "from hydropandas.io.waterinfo import get_locations_gdf\n",
+    "\n",
+    "# enabling debug logging so we can see what happens in the background\n",
+    "hpd.util.get_color_logger(\"INFO\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# settings\n",
+    "grootheid_code = None\n",
+    "locatie = 'SCHOONHVN'\n",
+    "tmin = dt.datetime(2024, 1, 1)\n",
+    "tmax = dt.datetime(2024, 1, 3)\n",
+    "extent = (110000, 125000, 429550, 449900) # Schoonhoven"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get waterinfo observations within an extent\n",
+    "oc = hpd.read_waterinfo(\n",
+    "    extent=extent, grootheid_code=grootheid_code, locatie=locatie, tmin=tmin, tmax=tmax\n",
+    ")\n",
+    "oc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show all measurement types within the extent\n",
+    "gdf_meas = get_locations_gdf(extent=extent)\n",
+    "gdf_meas[['Grootheid.Code','Grootheid.Omschrijving']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get data from a certain location and grootheid\n",
+    "o = hpd.WaterlvlObs.from_waterinfo(\n",
+    "    locatie='SCHOONHVN',\n",
+    "    grootheid_code='WATHTE',\n",
+    "    tmin=tmin,\n",
+    "    tmax=tmax,\n",
+    "    location_gdf=gdf_meas, #specifying the location_gdf signficantly speeds up the process\n",
+    ")\n",
+    "o.plot(ylabel=o.unit, title=o.name, legend=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get data from a certain location and grootheid\n",
+    "o = hpd.WaterlvlObs.from_waterinfo(\n",
+    "    locatie='SCHOONHVN',\n",
+    "    grootheid_code='WATHTBRKD',\n",
+    "    tmin=tmin,\n",
+    "    tmax=tmax,\n",
+    "    location_gdf=gdf_meas, #specifying the location_gdf signficantly speeds up the process\n",
+    ")\n",
+    "o.plot(ylabel=o.unit, title=o.name, legend=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get all measurement points within the Netherlands\n",
+    "gdf = hpd.io.waterinfo.get_locations_gdf()\n",
+    "ax = gdf.plot(figsize=(10,10))\n",
+    "nlmod.plot.add_background_map(ax=ax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ophalen data WaterWebservices <a id=GroundwaterObs></a>\n",
+    "\n",
+    "In de toekomst komen de WaterWebservices beschikbaar. Deze werken op dit moment (2024-2-26) nog niet. Bij het ophalen van de metingen wordt altijd aangegeven dat het maximaal aantal metingen wordt overschreven. Zelfs als je maar voor één dag metingen ophaalt.\n",
+    "\n",
+    "Handige links:\n",
+    "- https://waterwebservices.beta.rijkswaterstaat.nl/test/swagger-ui/index.html#/\n",
+    "- https://rijkswaterstaatdata.nl/projecten/beta-waterwebservices/\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "import pandas as pd\n",
+    "from shapely.geometry import Point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# request catalogus REST API\n",
+    "url = \"https://waterwebservices.beta.rijkswaterstaat.nl/test/METADATASERVICES/OphalenCatalogus\"\n",
+    "body = {\"CatalogusFilter\": {\"Compartimenten\":True, \"Grootheden\":True}}\n",
+    "headers = {\"content-type\": \"application/json\"}\n",
+    "r = requests.post(url,  data=json.dumps(body), headers=headers)\n",
+    "\n",
+    "out = r.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot locations from REST API\n",
+    "geometries = [Point(loc['Lon'], loc['Lat']) for loc in out['LocatieLijst']]\n",
+    "gdf = gpd.GeoDataFrame(out['LocatieLijst'], geometry=geometries, crs=4258)\n",
+    "gdf.to_crs(28992, inplace=True)\n",
+    "extent_nl_poly = nlmod.util.polygon_from_extent([482.06, 306602.42, 284182.97, 637049.52])\n",
+    "gdf = gdf.loc[gdf.within(extent_nl_poly)]\n",
+    "ax = gdf.plot(figsize=(10,10))\n",
+    "nlmod.plot.add_background_map(ax=ax)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read REST API using an extent (Schoonhoven zuid-west)\n",
+    "extent_schoon = nlmod.util.polygon_from_extent((117850, 118180, 439550, 439900))\n",
+    "gdf_schoon = gdf.loc[gdf.within(extent_schoon.buffer(10000))]\n",
+    "ax = gdf_schoon.plot('Code',figsize=(10,10), legend=True)\n",
+    "nlmod.plot.add_background_map(ax=ax, alpha=0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# kies code en laat zien welke parameters erbij horen\n",
+    "code = 'schoonhoven'\n",
+    "\n",
+    "df_meta_locatie = pd.DataFrame(out['AquoMetadataLocatieLijst']).set_index('Locatie_MessageID')\n",
+    "df_meta = pd.DataFrame(out['AquoMetadataLijst'])\n",
+    "\n",
+    "locatie_message_id = gdf.loc[gdf['Code']==code,'Locatie_MessageID'].iloc[0]\n",
+    "\n",
+    "AquoMetaData_MessageIDs = df_meta_locatie.loc[locatie_message_id, 'AquoMetaData_MessageID']\n",
+    "if isinstance(AquoMetaData_MessageIDs, int):\n",
+    "    AquoMetaData_MessageIDs = [AquoMetaData_MessageIDs]\n",
+    "df_meta.loc[AquoMetaData_MessageIDs]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# request om metingen op te halen\n",
+    "code = 'ameland.nes'\n",
+    "aquometadata_message_id = 6\n",
+    "\n",
+    "url = \"https://waterwebservices.beta.rijkswaterstaat.nl/test/ONLINEWAARNEMINGENSERVICES/OphalenWaarnemingen\"\n",
+    "body = {\"Locatie\": {\"Code\": code},\n",
+    "        \"AquoPlusWaarnemingMetadata\":  {\"AquoMetadata\":{\"Compartiment\":{\"Code\":df_meta.loc[aquometadata_message_id,'Compartiment']['Code']}, \n",
+    "                                                        \"Grootheid\":{\"Code\":df_meta.loc[aquometadata_message_id,'Grootheid']['Code']}}},\n",
+    "        \"Periode\":{\"Begindatumtijd\":\"2024-06-01T00:00:00.000+01:00\",\n",
+    "                   \"Einddatumtijd\":\"2025-01-01T00:00:00.000+01:00\"}}\n",
+    "headers = {\"content-type\": \"application/json\"}\n",
+    "r = requests.post(url,  data=json.dumps(body), headers=headers)\n",
+    "if r.status_code==204:\n",
+    "    print('No data available')\n",
+    "else:\n",
+    "    meas = r.json()\n",
+    "    print(meas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# andere poging\n",
+    "code = 'ameland.nes'\n",
+    "aquometadata_message_id = 6\n",
+    "\n",
+    "url = \"https://waterwebservices.beta.rijkswaterstaat.nl/test/ONLINEWAARNEMINGENSERVICES/OphalenWaarnemingen\"\n",
+    "body = {\"Locatie\": {\"Code\": code},\n",
+    "        \"AquoPlusWaarnemingMetadata\":  {\"AquoMetadata\":{\"ProcesType\":\"verwachting\", \n",
+    "                                                        \"Grootheid\":{\"Code\":df_meta.loc[aquometadata_message_id,'Grootheid']['Code']}}},\n",
+    "        \"Periode\":{\"Begindatumtijd\":\"2024-01-01T00:00:00.000+01:00\",\n",
+    "                   \"Einddatumtijd\":\"2024-01-02T00:00:00.000+01:00\"}}\n",
+    "headers = {\"content-type\": \"application/json\"}\n",
+    "r = requests.post(url,  data=json.dumps(body), headers=headers)\n",
+    "if r.status_code==204:\n",
+    "    print('No data available')\n",
+    "else:\n",
+    "    meas = r.json()\n",
+    "    print(meas)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -71,7 +71,6 @@ class Obs(pd.DataFrame):
         the attributes listed in _metadata or keyword arguments for the constructor of a
         pandas.DataFrame.
         """
-        # print(self._metadata)
         if (len(args) > 0) and isinstance(args[0], Obs):
             for key in args[0]._get_meta_attr():
                 if (key in Obs._metadata) and (key not in kwargs):
@@ -86,7 +85,6 @@ class Obs(pd.DataFrame):
         self.source = kwargs.pop("source", "")
         self.unit = kwargs.pop("unit", "")
 
-        print(kwargs)
         super(Obs, self).__init__(*args, **kwargs)
 
     def __repr__(self) -> str:
@@ -546,7 +544,6 @@ class GroundwaterObs(Obs):
         "ground_level",
         "tube_top",
         "metadata_available",
-        "monitoring_well",
     ]
 
     def __init__(self, *args, **kwargs):
@@ -572,7 +569,7 @@ class GroundwaterObs(Obs):
         self.screen_top = kwargs.pop("screen_top", np.nan)
         self.screen_bottom = kwargs.pop("screen_bottom", np.nan)
         self.metadata_available = kwargs.pop("metadata_available", np.nan)
-        print(kwargs)
+
         super().__init__(*args, **kwargs)
 
     @property
@@ -583,6 +580,7 @@ class GroundwaterObs(Obs):
     def monitoring_well(self):
         msg = "The 'monitoring_well' attribute is deprecated and will be removed in hydropandas version 0.14.0., please use the 'location' attribute instead."
         warnings.warn(msg, FutureWarning)
+        raise ValueError("why?")
         return self.location
 
     @monitoring_well.setter
@@ -932,7 +930,6 @@ class WaterQualityObs(Obs):
         "tube_nr",
         "ground_level",
         "metadata_available",
-        "monitoring_well",
     ]
 
     def __init__(self, *args, **kwargs):
@@ -991,7 +988,7 @@ class WaterlvlObs(Obs):
     Subclass of the Obs class
     """
 
-    _metadata = Obs._metadata + ["metadata_available", "monitoring_well"]
+    _metadata = Obs._metadata + ["metadata_available"]
 
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
@@ -1038,13 +1035,32 @@ class WaterlvlObs(Obs):
         return cls(measurements, meta=meta, **meta)
 
     @classmethod
-    def from_waterinfo(cls, path, **kwargs):
+    def from_waterinfo(
+        cls,
+        path=None,
+        location_gdf=None,
+        grootheid_code=None,
+        locatie=None,
+        tmin=None,
+        tmax=None,
+        **kwargs,
+    ):
         """Read data from waterinfo csv-file or zip.
 
         Parameters
         ----------
-        path : str
+        path : str, optional
             path to file (file can zip or csv)
+        location_gdf : geopandas.GeoDataFrame, optional
+            geodataframe with locations, only used if path is None, default is None
+        grootheid_code : str, optional
+            code of the grootheid, only used if path is None, e.g. 'WATHTE', default is None
+        locatie : str, optional
+            name of the location, only used if path is None, e.g. 'SCHOONHVN', default is None
+        tmin : datetime, optional
+            start date of the measurements, only used if path is None, default is None
+        tmax : datetime, optional
+            end date of the measurements, only used if path is None, default is None
 
         Returns
         -------
@@ -1058,10 +1074,17 @@ class WaterlvlObs(Obs):
         """
         from .io import waterinfo
 
-        df, metadata = waterinfo.read_waterinfo_file(
-            path, return_metadata=True, **kwargs
+        df, metadata = waterinfo.get_waterinfo_obs(
+            path=path,
+            location_gdf=location_gdf,
+            grootheid_code=grootheid_code,
+            locatie=locatie,
+            tmin=tmin,
+            tmax=tmax,
+            **kwargs,
         )
-        return cls(df, meta=metadata, **metadata)
+
+        return cls(df, **metadata)
 
 
 class ModelObs(Obs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ full = [
     "pyproj",
     "contextily",
     "lxml",
+    "ddlpy",
 ]
 rtd = [
     "hydropandas[full]",

--- a/tests/test_001_to_from.py
+++ b/tests/test_001_to_from.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 
 import pandas as pd
@@ -369,6 +370,27 @@ def test_knmi_collection_from_grid():
 def test_waterinfo_from_dir():
     path = "./tests/data/2023-waterinfo-test"
     hpd.read_waterinfo(path)
+
+
+def test_waterinfo_ddlpy():
+    grootheid_code = "WATHTE"
+    locatie = "SCHOONHVN"
+    tmin = dt.datetime(2024, 1, 1)
+    tmax = dt.datetime(2024, 1, 2)
+    hpd.WaterlvlObs.from_waterinfo(
+        grootheid_code=grootheid_code, locatie=locatie, tmin=tmin, tmax=tmax
+    )
+
+
+def test_waterinfo_ddlpy_extent():
+    grootheid_code = "WATHTE"
+    tmin = dt.datetime(2024, 1, 1)
+    tmax = dt.datetime(2024, 1, 2)
+    extent = (110000, 125000, 429550, 449900)
+    oc = hpd.read_waterinfo(
+        extent=extent, grootheid_code=grootheid_code, tmin=tmin, tmax=tmax
+    )
+    assert not oc.empty
 
 
 # %% MENYANTHES


### PR DESCRIPTION
I added the option to read waterinfo data within an extent using `ddlpy`. It is mainly focussed on reading surface water levels WATHTE and not tested, it might be a bit buggy for other types of measurements.

