### PR TITLE
fix day shift

### DIFF
--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -159,7 +159,7 @@ def get_knmi_timeseries_fname(
     if "neerslaggeg" in fname:
         # neerslagstation
         meteo_var = "RD"
-        add_day = True
+        add_day = False
     elif "etmgeg" in fname:
         # meteo station
         add_day = True

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -799,7 +799,7 @@ def download_knmi_data(
             elif meteo_var == "RD":
                 # daily data from rainfall-stations
                 df, meta = get_knmi_daily_rainfall_url(stn, stn_name)
-                add_day = True
+                add_day = False
             else:
                 # daily data from meteorological stations
                 df, meta = get_knmi_daily_meteo_url(stn=stn)

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -178,13 +178,6 @@ def test_download_without_data():
 
 
 # %%
-
-# %%
-
-# %%
-
-
-# %%
 def test_fill_missing_measurements():
     settings = knmi._get_default_settings({"fill_missing_obs": True})
 
@@ -229,9 +222,6 @@ def test_fill_missing_measurements():
     # assert df.empty, "expected empty dataframe"
 
 
-# %% obs collections
-
-
 def test_obslist_from_grid():
     xy = [[x, y] for x in [104150.0, 104550.0] for y in [510150.0, 510550.0]]
 
@@ -270,9 +260,6 @@ def test_obslist_from_stns_single_startdate():
         ends="2015",
         ObsClasses=[hpd.PrecipitationObs, hpd.EvaporationObs],
     )
-
-
-# %%
 
 
 def test_knmi_meteo_station_hourly_api_values():

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -183,6 +183,7 @@ def test_download_without_data():
 
 # %%
 
+
 # %%
 def test_fill_missing_measurements():
     settings = knmi._get_default_settings({"fill_missing_obs": True})
@@ -436,8 +437,9 @@ def test_knmi_daily_rainfall():
         rtol=1e-8,
     )
 
+
 def test_meteo_station_methods():
-    """Test if 3 different ways (api, non-api and .txt file) of obtaining data from a meteo 
+    """Test if 3 different ways (api, non-api and .txt file) of obtaining data from a meteo
     station yield the same results"""
 
     start = pd.Timestamp("2000-1-1")
@@ -466,14 +468,16 @@ def test_meteo_station_methods():
 
 
 def test_rainfall_station_methods():
-    """Test if 3 different ways (api, non-api and .txt file) of obtaining data from a rainfall 
+    """Test if 3 different ways (api, non-api and .txt file) of obtaining data from a rainfall
     station yield the same results"""
 
     start = pd.Timestamp("2000-1-1")
     end = pd.Timestamp("2000-1-10")
 
-    # daily rainfall station 
-    precip1 = hpd.PrecipitationObs.from_knmi(stn=550, meteo_var="RD", start=start, end=end)
+    # daily rainfall station
+    precip1 = hpd.PrecipitationObs.from_knmi(
+        stn=550, meteo_var="RD", start=start, end=end
+    )
 
     # daily rainfall station without api
     precip2 = hpd.PrecipitationObs.from_knmi(

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -458,7 +458,7 @@ def test_meteo_station_methods():
 
     # daily meteo station from file
     precip3 = hpd.PrecipitationObs.from_knmi(
-        fname=r".\tests\data\2023-KNMI-test\etmgeg_260.txt",
+        fname=r"./tests/data/2023-KNMI-test/etmgeg_260.txt",
         start=start,
         end=end,
     )
@@ -490,7 +490,7 @@ def test_rainfall_station_methods():
 
     # daily rainfall station from file
     precip3 = hpd.PrecipitationObs.from_knmi(
-        fname=r".\tests\data\2023-KNMI-test\neerslaggeg_DE-BILT_550.txt",
+        fname=r"./tests/data/2023-KNMI-test/neerslaggeg_DE-BILT_550.txt",
         start=start,
         end=end,
     )

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -178,6 +178,12 @@ def test_download_without_data():
 
 
 # %%
+
+# %%
+
+# %%
+
+# %%
 def test_fill_missing_measurements():
     settings = knmi._get_default_settings({"fill_missing_obs": True})
 
@@ -394,11 +400,12 @@ def test_knmi_daily_rainfall_api_values():
     )
 
 
-def test_knmi_daily_rainfall_url_values():
+def test_knmi_daily_rainfall():
     stn = 550
     stn_name = knmi.get_station_name(stn=stn)
     start = pd.Timestamp("2000-01-01")
     end = pd.Timestamp("2000-12-31")
+
     # daily data from rainfall-stations
     df, meta = knmi.get_knmi_daily_rainfall_url(stn, stn_name)
 
@@ -428,3 +435,61 @@ def test_knmi_daily_rainfall_url_values():
         atol=1e-8,
         rtol=1e-8,
     )
+
+def test_meteo_station_methods():
+    """Test if 3 different ways (api, non-api and .txt file) of obtaining data from a meteo 
+    station yield the same results"""
+
+    start = pd.Timestamp("2000-1-1")
+    end = pd.Timestamp("2000-1-10")
+
+    # daily meteo station (default)
+    precip1 = hpd.PrecipitationObs.from_knmi(stn=260, start=start, end=end)
+
+    # daily meteo station without api
+    precip2 = hpd.PrecipitationObs.from_knmi(
+        stn=260,
+        start=start,
+        end=end,
+        use_api=False,
+    )
+
+    # daily meteo station from file
+    precip3 = hpd.PrecipitationObs.from_knmi(
+        fname=r".\tests\data\2023-KNMI-test\etmgeg_260.txt",
+        start=start,
+        end=end,
+    )
+
+    assert precip1.equals(precip2)
+    assert precip1.equals(precip3)
+
+
+def test_rainfall_station_methods():
+    """Test if 3 different ways (api, non-api and .txt file) of obtaining data from a rainfall 
+    station yield the same results"""
+
+    start = pd.Timestamp("2000-1-1")
+    end = pd.Timestamp("2000-1-10")
+
+    # daily rainfall station 
+    precip1 = hpd.PrecipitationObs.from_knmi(stn=550, meteo_var="RD", start=start, end=end)
+
+    # daily rainfall station without api
+    precip2 = hpd.PrecipitationObs.from_knmi(
+        meteo_var="RD",
+        stn=550,
+        start=start,
+        end=end,
+        use_api=False,
+    )
+
+    # daily rainfall station from file
+    precip3 = hpd.PrecipitationObs.from_knmi(
+        fname=r".\tests\data\2023-KNMI-test\neerslaggeg_DE-BILT_550.txt",
+        start=start,
+        end=end,
+    )
+
+    assert precip1.equals(precip2)
+    assert precip1.equals(precip3)


### PR DESCRIPTION
First I thought it was because of a change in pandas version but later I could not reproduce this with an earlier version of pandas.

In the code there was no day shift for the daily rainfall api method but there was a day shift for the non_api method.

This PR fixes that.

I feel like it should work now but it still feels a bit "unheimlich" because it is quite a persistent issue.