### PR TITLE
allow different epsg in read_bro

### DIFF
--- a/hydropandas/extensions/gwobs.py
+++ b/hydropandas/extensions/gwobs.py
@@ -521,6 +521,10 @@ class GwObsAccessor:
         -------
         pd.Series with the modellayers of each observation
         """
+        msg = ("the get_modellayers method is deprecated, please use the nlmod "
+                "function: nlmod.layer.get_modellayers_screens")
+        logger.warning(msg)
+
         modellayers = []
         for o in self._obj.obs.values:
             logger.debug("-" * 10 + f"\n {o.name}:")

--- a/hydropandas/extensions/gwobs.py
+++ b/hydropandas/extensions/gwobs.py
@@ -521,8 +521,10 @@ class GwObsAccessor:
         -------
         pd.Series with the modellayers of each observation
         """
-        msg = ("the get_modellayers method is deprecated, please use the nlmod "
-                "function: nlmod.layer.get_modellayers_screens")
+        msg = (
+            "the get_modellayers method is deprecated, please use the nlmod "
+            "function: nlmod.layer.get_modellayers_screens"
+        )
         logger.warning(msg)
 
         modellayers = []

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -680,15 +680,21 @@ def get_obs_list_from_extent(
             endDate = pd.to_datetime(tmax).strftime("%Y-%m-%d")
             data["registrationPeriod"]["endDate"] = endDate
 
-    transformer = Transformer.from_crs(epsg, 4326)
     data["area"] = {}
-    if extent is not None:
-        lat1, lon1 = transformer.transform(extent[0], extent[2])
-        lat2, lon2 = transformer.transform(extent[1], extent[3])
+    if epsg == 4326:
         data["area"]["boundingBox"] = {
-            "lowerCorner": {"lat": lat1, "lon": lon1},
-            "upperCorner": {"lat": lat2, "lon": lon2},
-        }
+                "lowerCorner": {"lat": extent[2], "lon": extent[0]},
+                "upperCorner": {"lat": extent[3], "lon": extent[1]},
+            }
+    else:
+        transformer = Transformer.from_crs(epsg, 4326)
+        if extent is not None:
+            lat1, lon1 = transformer.transform(extent[0], extent[2])
+            lat2, lon2 = transformer.transform(extent[1], extent[3])
+            data["area"]["boundingBox"] = {
+                "lowerCorner": {"lat": lat1, "lon": lon1},
+                "upperCorner": {"lat": lat2, "lon": lon2},
+            }
     req = requests.post(url, json=data)
     if req.status_code > 200:
         logger.error(

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -683,9 +683,9 @@ def get_obs_list_from_extent(
     data["area"] = {}
     if epsg == 4326:
         data["area"]["boundingBox"] = {
-                "lowerCorner": {"lat": extent[2], "lon": extent[0]},
-                "upperCorner": {"lat": extent[3], "lon": extent[1]},
-            }
+            "lowerCorner": {"lat": extent[2], "lon": extent[0]},
+            "upperCorner": {"lat": extent[3], "lon": extent[1]},
+        }
     else:
         transformer = Transformer.from_crs(epsg, 4326)
         if extent is not None:


### PR DESCRIPTION
Add the option to call read_bro with epsg 4326.

There was a problem with splitting a large extent in RD coördinates in multiple tiles because the tiles were converted to lat/lon (epsg 4326) individually which caused overlapping tiles. This PR solves that