### PR TITLE
Lizard IO: Catch exception if no wells found

### DIFF
--- a/hydropandas/io/lizard.py
+++ b/hydropandas/io/lizard.py
@@ -710,6 +710,13 @@ def get_obs_list_from_extent(
     logger.info("Number of monitoring wells: {}".format(nr_results))
     logger.info("Number of pages: {}".format(nr_pages))
 
+    if nr_results == 0:
+        logger.warning(
+            "No monitoring wells found in the specified extent. "
+            "Please check the extent or the source."
+        )
+        return []
+
     if nr_threads > nr_pages:
         nr_threads = nr_pages
 


### PR DESCRIPTION
If the selected extents do not contain wells, the original code yielded the following: ValueError("max_workers must be greater than 0"), which is not very informative.

Code to reproduce behavior before and after:

```
import hydropandas as hpd

hpd.util.get_color_logger("INFO")
my_extent = (85000, 860000, 410000, 412000)
oc_lizard = hpd.read_lizard(extent=my_extent, only_metadata=True)
oc_lizard
```
