### PR TITLE
Sort observations if index is not monotonic increasing

### DIFF
--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -95,6 +95,9 @@ def get_obs_list_from_gmn(bro_id, ObsClass, only_metadata=False, keep_all_obs=Tr
             )
             if keep_all_obs:
                 obs_list.append(o)
+        elif not o.index.is_monotonic_increasing:
+            o = o.sort_index()
+            obs_list.append(o)
         else:
             obs_list.append(o)
         obs_list.append(o)
@@ -757,6 +760,9 @@ def get_obs_list_from_extent(
                 )
                 if keep_all_obs:
                     obs_list.append(o)
+            elif not o.index.is_monotonic_increasing:
+                o = o.sort_index()
+                obs_list.append(o)
             else:
                 obs_list.append(o)
 


### PR DESCRIPTION
For some BRO wells (e.g. `GMW000000028739_1`), the index (datetime) values are not monotonicly increasing. This results in unexpected behavior such as a straight-line (from the starting to the end point), in time series plots and NaN values when performing basic statistics (mean, min, max, etc.). I applied a fix in the code, but I can imagine you would mabye want to add an optional argument to the from_bro method to handle this case more explicitly.