### PR TITLE
Replace tqdm.auto by tqdm

### DIFF
--- a/hydropandas/extensions/plots.py
+++ b/hydropandas/extensions/plots.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.gridspec import GridSpec
-from tqdm.auto import tqdm
+from tqdm import tqdm
 
 from ..observation import GroundwaterObs
 from . import accessor


### PR DESCRIPTION
When importing hydropandas, I get the following warning:

```
TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
  from .autonotebook import tqdm as notebook_tqdm
```

This is because I have not installed jupyter in my environment. Therfore I am in favor of just importing `tqdm` from `tqdm`, and not from `tqdm.auto`. This will fix the warning I get at the start of every script. I do not know if this causes problems for others though.