### PR TITLE
Lizard: read multiple pages for get_timeseries_uuid

### DIFF
--- a/hydropandas/io/lizard.py
+++ b/hydropandas/io/lizard.py
@@ -473,8 +473,8 @@ def get_timeseries_uuid(
             ):
                 all_page_results.extend(result)
 
-        # Combine first page with additional pages
-        time_series_events = time_series_events + all_page_results
+        # Use results from all pages
+        time_series_events = all_page_results
 
     # Convert to DataFrame and process (existing logic)
     if not time_series_events:

--- a/hydropandas/io/lizard.py
+++ b/hydropandas/io/lizard.py
@@ -444,8 +444,8 @@ def get_timeseries_uuid(
     # Calculate number of pages needed
     nr_pages = math.ceil(total_count / page_size)
 
-    logger.info(f"Number of timeseries events: {total_count}")
-    logger.info(f"Number of pages: {nr_pages}")
+    #logger.info(f"Number of timeseries events: {total_count}")
+    #logger.info(f"Number of pages: {nr_pages}")
 
     # If only one page, return first page results
     if nr_pages <= 1:

--- a/hydropandas/io/lizard.py
+++ b/hydropandas/io/lizard.py
@@ -444,8 +444,8 @@ def get_timeseries_uuid(
     # Calculate number of pages needed
     nr_pages = math.ceil(total_count / page_size)
 
-    #logger.info(f"Number of timeseries events: {total_count}")
-    #logger.info(f"Number of pages: {nr_pages}")
+    # logger.info(f"Number of timeseries events: {total_count}")
+    # logger.info(f"Number of pages: {nr_pages}")
 
     # If only one page, return first page results
     if nr_pages <= 1:

--- a/hydropandas/io/lizard.py
+++ b/hydropandas/io/lizard.py
@@ -389,6 +389,7 @@ def get_metadata_tube(metadata_mw, tube_nr, auth=None):
 
     return metadata
 
+
 def get_timeseries_uuid(
     uuid, tmin, tmax, page_size=100000, nr_threads=10, organisation="vitens", auth=None
 ):
@@ -433,16 +434,16 @@ def get_timeseries_uuid(
     first_response = requests.get(url=url_timeseries, params=params, auth=auth)
     first_response.raise_for_status()
     first_data = first_response.json()
-    
+
     total_count = first_data.get("count", 0)
     time_series_events = first_data.get("results", [])
-    
+
     if total_count == 0:
         return pd.DataFrame()
 
     # Calculate number of pages needed
     nr_pages = math.ceil(total_count / page_size)
-    
+
     logger.info(f"Number of timeseries events: {total_count}")
     logger.info(f"Number of pages: {nr_pages}")
 
@@ -452,11 +453,12 @@ def get_timeseries_uuid(
     else:
         # Multi-page: use existing helper functions with ThreadPoolExecutor
         from urllib.parse import urlencode
+
         base_url_with_params = url_timeseries + "?" + urlencode(params)
-        
+
         # Prepare URLs for all pages using existing helper
         urls = _prepare_API_input(nr_pages, base_url_with_params)
-        
+
         # Adjust nr_threads if more threads than pages
         if nr_threads > nr_pages:
             nr_threads = nr_pages
@@ -470,7 +472,7 @@ def get_timeseries_uuid(
                 desc=f"Downloading timeseries {uuid}",
             ):
                 all_page_results.extend(result)
-        
+
         # Combine first page with additional pages
         time_series_events = time_series_events + all_page_results
 
@@ -491,9 +493,12 @@ def get_timeseries_uuid(
     timeseries_sel.set_index("time", inplace=True)
     timeseries_sel.index.rename("peil_datum_tijd", inplace=True)
 
-    logger.info(f"Successfully retrieved {len(timeseries_sel)} timeseries events for UUID {uuid}")
+    logger.info(
+        f"Successfully retrieved {len(timeseries_sel)} timeseries events for UUID {uuid}"
+    )
 
     return timeseries_sel
+
 
 def _filter_timeseries(ts_dict, datafilters):
     """


### PR DESCRIPTION
The existing function `get_timeseries_uuid` by default reads the first 100.000 measurements. If there are more pages, these would not be loaded. The suggested change reads following pages as well.

I used the following lines to test my solution. We may add them to the test suite if desired. All tested page sizes yield 969 rows which corresponds to the response of the [API endpoint](https://vitens.lizard.net/api/v4/timeseries/2c66fc7b-9fb4-473d-abfd-fd924a38a8cf/events/) page.
```python
import hydropandas.io.lizard
uuid = "2c66fc7b-9fb4-473d-abfd-fd924a38a8cf" 
tmin = None
tmax = None

page_sizes = [10, 100, 1000, 10_000, 100_000]
for page_size in page_sizes:
    df = hydropandas.io.lizard.get_timeseries_uuid(
        uuid=uuid, tmin=tmin, tmax=tmax, page_size=page_size
    )
    print(f"Page size {page_size} yields {df.shape[0]} rows")
```