### PR TITLE
Update `get_first_numeric_col_name`

### DIFF
--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -249,7 +249,7 @@ class Obs(pd.DataFrame):
         If there are no observations, but the DataFrame has columns with numeric datatype,
         then still the first numeric column name is returned.
         """
-        
+
         for col in self.columns:
             if is_numeric_dtype(self[col]):
                 return col

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -243,10 +243,13 @@ class Obs(pd.DataFrame):
         -------
         col : str, int or None
             Column name. None if there are no numeric columns.
-        """
-        if self.empty:
-            return None
 
+        Notes
+        -----
+        If there are no observations, but the DataFrame has columns with numeric datatype,
+        then still the first numeric column name is returned.
+        """
+        
         for col in self.columns:
             if is_numeric_dtype(self[col]):
                 return col


### PR DESCRIPTION
The old function `get_first_numeric_col_name` would yield `None` when no rows are available in the Obs dataframe. This is not desirable. The function should still yield the column name (e.g.: `value`) even if no rows are available.

This fixes #331 completely, so I will close that issue.
Issue #332 is fixed partially by this commit. `to_pastastore` will now create files but these do not yet include the metadata. I have tried to figure where it goes wrong, but not yet found the cause.

