### PR TITLE
Use python-backage `brodata` to download groundwater heads from BRO

### DIFF
--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -28,7 +28,9 @@ from ..util import EPSG_28992
 logger = logging.getLogger(__name__)
 
 
-def get_obs_list_from_gmn(bro_id, ObsClass, only_metadata=False, keep_all_obs=True):
+def get_obs_list_from_gmn(
+    bro_id, ObsClass, only_metadata=False, keep_all_obs=True, method="internal"
+):
     """get a list of observation from a groundwater monitoring network.
 
     Parameters
@@ -43,6 +45,10 @@ def get_obs_list_from_gmn(bro_id, ObsClass, only_metadata=False, keep_all_obs=Tr
     keep_all_obs : boolean, optional
         add all observation points to the collection, even without
         measurements
+    method : str
+        The method to use for requesting data from the bro-database. When method is
+        'internal', use internal logic in hydropandas. When method is 'brodata', use the
+        python-package `brodata`. The default is 'internal'.
 
     Raises
     ------
@@ -60,6 +66,26 @@ def get_obs_list_from_gmn(bro_id, ObsClass, only_metadata=False, keep_all_obs=Tr
 
     if not bro_id.startswith("GMN"):
         raise ValueError("bro id should start with GMN")
+
+    if method == "brodata":
+        import brodata
+
+        gmn = brodata.gmn.GroundwaterMonitoringNetwork.from_bro_id(bro_id)
+        gmw_ids = gmn.measuringPoint.index.levels[0].unique()
+        gmws = brodata.gmw.get_data_for_bro_ids(gmw_ids)
+        obs_list = []
+        for gmw_id, tube_number in gmn.measuringPoint.index:
+            if only_metadata:
+                df = brodata.gld._get_empty_observation_df()
+            else:
+                df = brodata.gmw.get_tube_observations(gmw_id, tube_number)
+                df = df.rename(columns={"value": "values"})
+            meta = _brodata_gmw_to_meta(gmws[gmw_id], tube_number)
+            o = ObsClass(df, **meta)
+            obs_list.append(o)
+
+        meta = {"name": gmn.name, "doel": gmn.monitoringPurpose, "bro_id": bro_id}
+        return obs_list, meta
 
     url = f"https://publiek.broservices.nl/gm/gmn/v1/objects/{bro_id}"
     req = requests.get(url)
@@ -97,7 +123,6 @@ def get_obs_list_from_gmn(bro_id, ObsClass, only_metadata=False, keep_all_obs=Tr
                 obs_list.append(o)
         else:
             obs_list.append(o)
-        obs_list.append(o)
 
     meta = {}
     meta["name"] = gmn.find("xmlns:name", ns).text
@@ -107,7 +132,9 @@ def get_obs_list_from_gmn(bro_id, ObsClass, only_metadata=False, keep_all_obs=Tr
     return obs_list, meta
 
 
-def get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, **kwargs):
+def get_bro_groundwater(
+    bro_id, tube_nr=None, only_metadata=False, method="internal", **kwargs
+):
     """get bro groundwater measurement from a GLD id or a GMW id with a
     filter number.
 
@@ -122,6 +149,10 @@ def get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, **kwargs):
     only_metadata : bool, optional
         if True download only metadata, significantly faster. The default
         is False.
+    method : str
+        The method to use for requesting data from the bro-database. When method is
+        'internal', use internal logic in hydropandas. When method is 'brodata', use the
+        python-package `brodata`. The default is 'internal'.
     **kwargs :
         passes to measurements_from_gld.
 
@@ -143,20 +174,42 @@ def get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, **kwargs):
     if bro_id.startswith("GLD"):
         if only_metadata:
             raise ValueError("cannot get metadata from gld id")
+        if method == "brodata":
+            import brodata
+
+            gld = brodata.gld.GroundwaterLevelDossier.from_bro_id(bro_id)
+            df = gld.observation.rename(columns={"value": "values"})
+            meta = get_metadata_from_gmw(
+                gld.groundwaterMonitoringWell, gld.tubeNumber, method=method
+            )
+            return df, meta
         return measurements_from_gld(bro_id, **kwargs)
 
     elif bro_id.startswith("GMW"):
         if tube_nr is None:
             raise ValueError("if bro_id is GMW a tube_nr should be specified")
+        meta = get_metadata_from_gmw(bro_id, tube_nr, method=method)
+        if method == "brodata":
+            import brodata
 
-        meta = get_metadata_from_gmw(bro_id, tube_nr)
+            obs_df = brodata.gmw.get_observations(bro_id, tube_number=tube_nr)
+
+            if len(obs_df) == 0:
+                df = brodata.gld._get_empty_observation_df()
+            elif len(obs_df) == 1:
+                df = obs_df.iloc[0]["observation"]
+            else:
+                df = brodata.gmw._combine_observations(
+                    obs_df["observation"], kind="gld", bro_id=meta["name"]
+                )
+            return df, meta
+
         gld_ids = get_gld_ids_from_gmw(bro_id, tube_nr)
 
+        meta["name"] = f"{bro_id}_{tube_nr}"
         if gld_ids is None:
-            meta["name"] = f"{bro_id}_{tube_nr}"
             only_metadata = True  # cannot get time series without gld id
         else:
-            meta["name"] = f"{bro_id}_{tube_nr}"
             meta["gld_ids"] = gld_ids
 
         if only_metadata:
@@ -353,7 +406,7 @@ def measurements_from_gld(
     return df, meta
 
 
-def get_full_metadata_from_gmw(bro_id, tube_nr):
+def get_full_metadata_from_gmw(bro_id, tube_nr, method="internal"):
     """get metadata for a groundwater monitoring well.
 
 
@@ -363,6 +416,10 @@ def get_full_metadata_from_gmw(bro_id, tube_nr):
         bro id of groundwater monitoring well e.g. 'GMW000000036287'.
     tube_nr : int
         filter number you want metadata for.
+    method : str
+        The method to use for requesting data from the bro-database. When method is
+        'internal', use internal logic in hydropandas. When method is 'brodata', use the
+        python-package `brodata`. The default is 'internal'.
 
     Raises
     ------
@@ -375,6 +432,14 @@ def get_full_metadata_from_gmw(bro_id, tube_nr):
         dictionary with metadata.
 
     """
+    if method == "brodata":
+        import brodata
+
+        gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
+        _check_tube_number(bro_id, tube_nr, gmw.monitoringTube.index)
+        tube_gdf = brodata.gmw.get_tube_gdf([gmw])
+        meta = tube_gdf.loc[(bro_id, tube_nr)].to_dict()
+        return meta
 
     if not bro_id.startswith("GMW"):
         raise ValueError("can only get metadata if bro id starts with GMW")
@@ -528,7 +593,25 @@ def get_tube_nrs_from_gmw(bro_id):
     return tube_numbers
 
 
-def get_metadata_from_gmw(bro_id, tube_nr):
+def _brodata_gmw_to_meta(gmw, tube_nr):
+    meta = {
+        "name": f"{gmw.broId}_{tube_nr}",
+        "location": gmw.broId,
+        "tube_nr": tube_nr,
+        "source": "BRO",
+        "x": gmw.deliveredLocation.x,
+        "y": gmw.deliveredLocation.y,
+        "unit": "m NAP",
+        "ground_level": gmw.groundLevelPosition,
+        "tube_top": gmw.monitoringTube.at[tube_nr, "tubeTopPosition"],
+        "screen_top": gmw.monitoringTube.at[tube_nr, "screenTopPosition"],
+        "screen_bottom": gmw.monitoringTube.at[tube_nr, "screenBottomPosition"],
+        "metadata_available": True,
+    }
+    return meta
+
+
+def get_metadata_from_gmw(bro_id, tube_nr, method="internal"):
     """get selection of metadata for a groundwater monitoring well.
     coordinates, ground_level, tube_top and tube screen
 
@@ -538,6 +621,10 @@ def get_metadata_from_gmw(bro_id, tube_nr):
         bro id of groundwater monitoring well e.g. 'GMW000000036287'.
     tube_nr : int
         tube number you want metadata for.
+    method : str
+        The method to use for requesting data from the bro-database. When method is
+        'internal', use internal logic in hydropandas. When method is 'brodata', use the
+        python-package `brodata`. The default is 'internal'.
 
     Raises
     ------
@@ -552,6 +639,14 @@ def get_metadata_from_gmw(bro_id, tube_nr):
         dictionary with metadata.
 
     """
+    if method == "brodata":
+        import brodata
+
+        gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
+        _check_tube_number(bro_id, tube_nr, gmw.monitoringTube.index)
+        meta = _brodata_gmw_to_meta(gmw, tube_nr)
+
+        return meta
     if not isinstance(tube_nr, int):
         raise TypeError(f"expected integer got {type(tube_nr)}")
 
@@ -597,11 +692,7 @@ def get_metadata_from_gmw(bro_id, tube_nr):
     # buis eigenschappen
     tubes = gmw.findall("dsgmw:monitoringTube", ns)
     tube_nrs = [int(tube.find("dsgmw:tubeNumber", ns).text) for tube in tubes]
-    if tube_nr not in tube_nrs:
-        raise ValueError(
-            f"gmw {bro_id} has no tube_nr {tube_nr} please choose a tube_nr from"
-            f"{tube_nrs}"
-        )
+    _check_tube_number(bro_id, tube_nr, tube_nrs)
     tube = tubes[tube_nrs.index(tube_nr)]
 
     # tube_top
@@ -624,6 +715,14 @@ def get_metadata_from_gmw(bro_id, tube_nr):
     return meta
 
 
+def _check_tube_number(bro_id, tube_nr, tube_nrs):
+    if tube_nr not in tube_nrs:
+        raise ValueError(
+            f"gmw {bro_id} has no tube_nr {tube_nr} please choose a tube_nr from"
+            f"{tube_nrs}"
+        )
+
+
 def get_obs_list_from_extent(
     extent,
     ObsClass,
@@ -633,6 +732,7 @@ def get_obs_list_from_extent(
     keep_all_obs=True,
     epsg=28992,
     ignore_max_obs=False,
+    method="internal",
 ):
     """get a list of gmw observations within an extent.
 
@@ -657,6 +757,10 @@ def get_obs_list_from_extent(
         by default you get a prompt if you want to download over a 1000
         observations at once. if ignore_max_obs is True you won't get the
         prompt. The default is False
+    method : str
+        The method to use for requesting data from the bro-database. When method is
+        'internal', use internal logic in hydropandas. When method is 'brodata', use the
+        python-package `brodata`. The default is 'internal'.
 
     Raises
     ------
@@ -675,6 +779,51 @@ def get_obs_list_from_extent(
             "you will get an empty ObsCollection with only_metadata is True and"
             "keep_all_obs is False"
         )
+    if method.startswith("brodata"):
+        import brodata
+
+        obs_list = []
+        if only_metadata:
+            kind = None
+        else:
+            kind = "gld"
+
+        use_gm = method == "brodata_gm"
+        if use_gm:
+            # use Grondwatermonitoring (GM) in samenhang
+            # so we do not have to download each individual Groundwater Monitoring Well
+            gdf = brodata.gm.get_data_in_extent(
+                extent, kind=kind, tmin=tmin, tmax=tmax, combine=True
+            )
+        else:
+            gdf = brodata.gmw.get_data_in_extent(
+                extent, kind=kind, tmin=tmin, tmax=tmax, combine=True
+            )
+
+        for index in gdf.index:
+            kwargs = dict(
+                name=f"{index[0]}_{index[1]}",
+                x=gdf.geometry[index].x,
+                y=gdf.geometry[index].y,
+                location=index[0],
+                tube_nr=index[1],
+                metadata_available=True,
+            )
+            if use_gm:
+                kwargs["screen_top"] = gdf.at[index, "screen_top_position"]
+                kwargs["screen_bottom"] = gdf.at[index, "screen_bottom_position"]
+            else:
+                kwargs["tube_top"] = gdf.at[index, "tubeTopPosition"]
+                kwargs["ground_level"] = gdf.at[index, "groundLevelPosition"]
+                kwargs["screen_top"] = gdf.at[index, "screenTopPosition"]
+                kwargs["screen_bottom"] = gdf.at[index, "screenBottomPosition"]
+
+            if only_metadata:
+                o = ObsClass(**kwargs)
+            else:
+                o = ObsClass(gdf.at[index, "observation"], **kwargs)
+            obs_list.append(o)
+        return obs_list
 
     url = "https://publiek.broservices.nl/gm/gmw/v1/characteristics/searches?"
 

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -192,16 +192,7 @@ def get_bro_groundwater(
         if method == "brodata":
             import brodata
 
-            obs_df = brodata.gmw.get_observations(bro_id, tube_number=tube_nr)
-
-            if len(obs_df) == 0:
-                df = brodata.gld._get_empty_observation_df()
-            elif len(obs_df) == 1:
-                df = obs_df.iloc[0]["observation"]
-            else:
-                df = brodata.gmw._combine_observations(
-                    obs_df["observation"], kind="gld", bro_id=meta["name"]
-                )
+            df = brodata.gmw.get_tube_observations(bro_id, tube_number=tube_nr)
             return df, meta
 
         gld_ids = get_gld_ids_from_gmw(bro_id, tube_nr)

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -762,8 +762,10 @@ def get_obs_list_from_extent(
         Grondwatermonitoring (GM) in samenhang - karakteristieken, hosted by PDOK. This
         up-to-date dataset combines well- and tube-properties. So users do not have to
         download each individual Groundwater Monitoring Well (GMW), which speeds up the
-        request. The Groundwater Level Dossiers (GLD) are still downloaded individually.
-        The default is True.
+        request. The gm-dataset does not contain the attributes `tube_top` and
+        `ground_level`, so you need to set use_gm=False if you need those. The
+        Groundwater Level Dossiers (GLD) are still downloaded individually. The default
+        is True.
 
     Raises
     ------

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -29,7 +29,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_obs_list_from_gmn(
-    bro_id, ObsClass, only_metadata=False, keep_all_obs=True, method="internal"
+    bro_id,
+    ObsClass,
+    only_metadata=False,
+    keep_all_obs=True,
+    use_brodata=True,
 ):
     """get a list of observation from a groundwater monitoring network.
 
@@ -45,10 +49,10 @@ def get_obs_list_from_gmn(
     keep_all_obs : boolean, optional
         add all observation points to the collection, even without
         measurements
-    method : str
-        The method to use for requesting data from the bro-database. When method is
-        'internal', use internal logic in hydropandas. When method is 'brodata', use the
-        python-package `brodata`. The default is 'internal'.
+    use_brodata : str
+        When True, use the python-package `brodata` for requesting data from the
+        bro-database. When False, use internal logic in hydropandas. The default is
+        False.
 
     Raises
     ------
@@ -67,7 +71,7 @@ def get_obs_list_from_gmn(
     if not bro_id.startswith("GMN"):
         raise ValueError("bro id should start with GMN")
 
-    if method == "brodata":
+    if use_brodata:
         import brodata
 
         gmn = brodata.gmn.GroundwaterMonitoringNetwork.from_bro_id(bro_id)
@@ -133,7 +137,7 @@ def get_obs_list_from_gmn(
 
 
 def get_bro_groundwater(
-    bro_id, tube_nr=None, only_metadata=False, method="internal", **kwargs
+    bro_id, tube_nr=None, only_metadata=False, use_brodata=False, **kwargs
 ):
     """get bro groundwater measurement from a GLD id or a GMW id with a
     filter number.
@@ -149,10 +153,10 @@ def get_bro_groundwater(
     only_metadata : bool, optional
         if True download only metadata, significantly faster. The default
         is False.
-    method : str
-        The method to use for requesting data from the bro-database. When method is
-        'internal', use internal logic in hydropandas. When method is 'brodata', use the
-        python-package `brodata`. The default is 'internal'.
+    use_brodata : str
+        When True, use the python-package `brodata` for requesting data from the
+        bro-database. When False, use internal logic in hydropandas. The default is
+        False.
     **kwargs :
         passes to measurements_from_gld.
 
@@ -174,13 +178,13 @@ def get_bro_groundwater(
     if bro_id.startswith("GLD"):
         if only_metadata:
             raise ValueError("cannot get metadata from gld id")
-        if method == "brodata":
+        if use_brodata:
             import brodata
 
             gld = brodata.gld.GroundwaterLevelDossier.from_bro_id(bro_id)
             df = gld.observation.rename(columns={"value": "values"})
             meta = get_metadata_from_gmw(
-                gld.groundwaterMonitoringWell, gld.tubeNumber, method=method
+                gld.groundwaterMonitoringWell, gld.tubeNumber, use_brodata=use_brodata
             )
             return df, meta
         return measurements_from_gld(bro_id, **kwargs)
@@ -188,8 +192,8 @@ def get_bro_groundwater(
     elif bro_id.startswith("GMW"):
         if tube_nr is None:
             raise ValueError("if bro_id is GMW a tube_nr should be specified")
-        meta = get_metadata_from_gmw(bro_id, tube_nr, method=method)
-        if method == "brodata":
+        meta = get_metadata_from_gmw(bro_id, tube_nr, use_brodata=use_brodata)
+        if use_brodata:
             import brodata
 
             df = brodata.gmw.get_tube_observations(bro_id, tube_number=tube_nr)
@@ -397,7 +401,7 @@ def measurements_from_gld(
     return df, meta
 
 
-def get_full_metadata_from_gmw(bro_id, tube_nr, method="internal"):
+def get_full_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
     """get metadata for a groundwater monitoring well.
 
 
@@ -407,10 +411,10 @@ def get_full_metadata_from_gmw(bro_id, tube_nr, method="internal"):
         bro id of groundwater monitoring well e.g. 'GMW000000036287'.
     tube_nr : int
         filter number you want metadata for.
-    method : str
-        The method to use for requesting data from the bro-database. When method is
-        'internal', use internal logic in hydropandas. When method is 'brodata', use the
-        python-package `brodata`. The default is 'internal'.
+    use_brodata : str
+        When True, use the python-package `brodata` for requesting data from the
+        bro-database. When False, use internal logic in hydropandas. The default is
+        False.
 
     Raises
     ------
@@ -423,7 +427,7 @@ def get_full_metadata_from_gmw(bro_id, tube_nr, method="internal"):
         dictionary with metadata.
 
     """
-    if method == "brodata":
+    if use_brodata:
         import brodata
 
         gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
@@ -602,7 +606,7 @@ def _brodata_gmw_to_meta(gmw, tube_nr):
     return meta
 
 
-def get_metadata_from_gmw(bro_id, tube_nr, method="internal"):
+def get_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
     """get selection of metadata for a groundwater monitoring well.
     coordinates, ground_level, tube_top and tube screen
 
@@ -612,10 +616,10 @@ def get_metadata_from_gmw(bro_id, tube_nr, method="internal"):
         bro id of groundwater monitoring well e.g. 'GMW000000036287'.
     tube_nr : int
         tube number you want metadata for.
-    method : str
-        The method to use for requesting data from the bro-database. When method is
-        'internal', use internal logic in hydropandas. When method is 'brodata', use the
-        python-package `brodata`. The default is 'internal'.
+    use_brodata : str
+        When True, use the python-package `brodata` for requesting data from the
+        bro-database. When False, use internal logic in hydropandas. The default is
+        False.
 
     Raises
     ------
@@ -630,7 +634,7 @@ def get_metadata_from_gmw(bro_id, tube_nr, method="internal"):
         dictionary with metadata.
 
     """
-    if method == "brodata":
+    if use_brodata:
         import brodata
 
         gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
@@ -723,7 +727,8 @@ def get_obs_list_from_extent(
     keep_all_obs=True,
     epsg=28992,
     ignore_max_obs=False,
-    method="internal",
+    use_brodata=False,
+    use_gm=True,
 ):
     """get a list of gmw observations within an extent.
 
@@ -748,10 +753,17 @@ def get_obs_list_from_extent(
         by default you get a prompt if you want to download over a 1000
         observations at once. if ignore_max_obs is True you won't get the
         prompt. The default is False
-    method : str
-        The method to use for requesting data from the bro-database. When method is
-        'internal', use internal logic in hydropandas. When method is 'brodata', use the
-        python-package `brodata`. The default is 'internal'.
+    use_brodata : str
+        When True, use the python-package `brodata` for requesting data from the
+        bro-database. When False, use internal logic in hydropandas. The default is
+        False.
+    use_gm : str
+        Only used when use_brodata=True. When use_gm=True, use the dataset
+        Grondwatermonitoring (GM) in samenhang - karakteristieken, hosted by PDOK. This
+        up-to-date dataset combines well- and tube-properties. So users do not have to
+        download each individual Groundwater Monitoring Well (GMW), which speeds up the
+        request. The Groundwater Level Dossiers (GLD) are still downloaded individually.
+        The default is True.
 
     Raises
     ------
@@ -770,7 +782,7 @@ def get_obs_list_from_extent(
             "you will get an empty ObsCollection with only_metadata is True and"
             "keep_all_obs is False"
         )
-    if method.startswith("brodata"):
+    if use_brodata:
         import brodata
 
         obs_list = []
@@ -779,7 +791,6 @@ def get_obs_list_from_extent(
         else:
             kind = "gld"
 
-        use_gm = method == "brodata_gm"
         if use_gm:
             # use Grondwatermonitoring (GM) in samenhang
             # so we do not have to download each individual Groundwater Monitoring Well

--- a/hydropandas/io/bro.py
+++ b/hydropandas/io/bro.py
@@ -28,14 +28,9 @@ from ..util import EPSG_28992
 logger = logging.getLogger(__name__)
 
 
-def get_obs_list_from_gmn(
-    bro_id,
-    ObsClass,
-    only_metadata=False,
-    keep_all_obs=True,
-    use_brodata=True,
-):
-    """get a list of observation from a groundwater monitoring network.
+def get_obs_list_from_gmn_hpd(bro_id, ObsClass, only_metadata=False, keep_all_obs=True):
+    """get a list of observation from a groundwater monitoring network using the
+    hydropandas engine.
 
     Parameters
     ----------
@@ -49,10 +44,6 @@ def get_obs_list_from_gmn(
     keep_all_obs : boolean, optional
         add all observation points to the collection, even without
         measurements
-    use_brodata : str
-        When True, use the python-package `brodata` for requesting data from the
-        bro-database. When False, use internal logic in hydropandas. The default is
-        False.
 
     Raises
     ------
@@ -67,30 +58,6 @@ def get_obs_list_from_gmn(
         metadata of the groundwater monitoring net.
 
     """
-
-    if not bro_id.startswith("GMN"):
-        raise ValueError("bro id should start with GMN")
-
-    if use_brodata:
-        import brodata
-
-        gmn = brodata.gmn.GroundwaterMonitoringNetwork.from_bro_id(bro_id)
-        gmw_ids = gmn.measuringPoint.index.levels[0].unique()
-        gmws = brodata.gmw.get_data_for_bro_ids(gmw_ids)
-        obs_list = []
-        for gmw_id, tube_number in gmn.measuringPoint.index:
-            if only_metadata:
-                df = brodata.gld._get_empty_observation_df()
-            else:
-                df = brodata.gmw.get_tube_observations(gmw_id, tube_number)
-                df = df.rename(columns={"value": "values"})
-            meta = _brodata_gmw_to_meta(gmws[gmw_id], tube_number)
-            o = ObsClass(df, **meta)
-            obs_list.append(o)
-
-        meta = {"name": gmn.name, "doel": gmn.monitoringPurpose, "bro_id": bro_id}
-        return obs_list, meta
-
     url = f"https://publiek.broservices.nl/gm/gmn/v1/objects/{bro_id}"
     req = requests.get(url)
 
@@ -136,8 +103,79 @@ def get_obs_list_from_gmn(
     return obs_list, meta
 
 
+def get_obs_list_from_gmn(
+    bro_id,
+    ObsClass,
+    only_metadata=False,
+    keep_all_obs=True,
+    engine="hydropandas",
+):
+    """get a list of observation from a groundwater monitoring network.
+
+    Parameters
+    ----------
+    bro_id : str
+        starts with 'GMN' e.g. 'GMN000000000163'.
+    ObsClass : type
+        class of the observations, so far only GroundwaterObs is supported
+    only_metadata : bool, optional
+        if True download only metadata, significantly faster. The default
+        is False.
+    keep_all_obs : boolean, optional
+        add all observation points to the collection, even without
+        measurements
+    engine : str, optional
+        Select how data from the bro-database is obtained, options are 'hydropandas' or
+        'brodata' The default is 'hydropandas'.
+
+    Raises
+    ------
+    ValueError
+        DESCRIPTION.
+
+    Returns
+    -------
+    obs_list : list
+        list with observation objects.
+    meta : dict
+        metadata of the groundwater monitoring net.
+
+    """
+
+    if not bro_id.startswith("GMN"):
+        raise ValueError("bro id should start with GMN")
+
+    if engine == "brodata":
+        import brodata
+
+        gmn = brodata.gmn.GroundwaterMonitoringNetwork.from_bro_id(bro_id)
+        gmw_ids = gmn.measuringPoint.index.levels[0].unique()
+        gmws = brodata.gmw.get_data_for_bro_ids(gmw_ids)
+        obs_list = []
+        for gmw_id, tube_number in gmn.measuringPoint.index:
+            if only_metadata:
+                df = brodata.gld._get_empty_observation_df()
+            else:
+                df = brodata.gmw.get_tube_observations(gmw_id, tube_number)
+                df = df.rename(columns={"value": "values"})
+            meta = _brodata_gmw_to_meta(gmws[gmw_id], tube_number)
+            o = ObsClass(df, **meta)
+            obs_list.append(o)
+
+        meta = {"name": gmn.name, "doel": gmn.monitoringPurpose, "bro_id": bro_id}
+
+    elif engine == "hydropandas":
+        obs_list, meta = get_obs_list_from_gmn_hpd(
+            bro_id, ObsClass, only_metadata=False, keep_all_obs=True
+        )
+    else:
+        raise ValueError(f"invalid engine selected {engine=}")
+
+    return obs_list, meta
+
+
 def get_bro_groundwater(
-    bro_id, tube_nr=None, only_metadata=False, use_brodata=False, **kwargs
+    bro_id, tube_nr=None, only_metadata=False, engine="hydropandas", **kwargs
 ):
     """get bro groundwater measurement from a GLD id or a GMW id with a
     filter number.
@@ -153,10 +191,9 @@ def get_bro_groundwater(
     only_metadata : bool, optional
         if True download only metadata, significantly faster. The default
         is False.
-    use_brodata : str
-        When True, use the python-package `brodata` for requesting data from the
-        bro-database. When False, use internal logic in hydropandas. The default is
-        False.
+    engine : str, optional
+        Select how data from the bro-database is obtained, options are 'hydropandas' or
+        'brodata' The default is 'hydropandas'.
     **kwargs :
         passes to measurements_from_gld.
 
@@ -178,47 +215,49 @@ def get_bro_groundwater(
     if bro_id.startswith("GLD"):
         if only_metadata:
             raise ValueError("cannot get metadata from gld id")
-        if use_brodata:
+        if engine == "hydropandas":
+            df, meta = measurements_from_gld(bro_id, **kwargs)
+        elif engine == "brodata":
             import brodata
 
             gld = brodata.gld.GroundwaterLevelDossier.from_bro_id(bro_id)
             df = gld.observation.rename(columns={"value": "values"})
             meta = get_metadata_from_gmw(
-                gld.groundwaterMonitoringWell, gld.tubeNumber, use_brodata=use_brodata
+                gld.groundwaterMonitoringWell, gld.tubeNumber, engine=engine
             )
-            return df, meta
-        return measurements_from_gld(bro_id, **kwargs)
+        else:
+            raise ValueError(f"invalid engine selected {engine=}")
 
     elif bro_id.startswith("GMW"):
         if tube_nr is None:
             raise ValueError("if bro_id is GMW a tube_nr should be specified")
-        meta = get_metadata_from_gmw(bro_id, tube_nr, use_brodata=use_brodata)
-        if use_brodata:
+        meta = get_metadata_from_gmw(bro_id, tube_nr, engine=engine)
+        if engine == "brodata":
             import brodata
 
             df = brodata.gmw.get_tube_observations(bro_id, tube_number=tube_nr)
-            return df, meta
+        elif engine == "hydropandas":
+            gld_ids = get_gld_ids_from_gmw(bro_id, tube_nr)
 
-        gld_ids = get_gld_ids_from_gmw(bro_id, tube_nr)
+            meta["name"] = f"{bro_id}_{tube_nr}"
+            if gld_ids is None:
+                only_metadata = True  # cannot get time series without gld id
+            else:
+                meta["gld_ids"] = gld_ids
 
-        meta["name"] = f"{bro_id}_{tube_nr}"
-        if gld_ids is None:
-            only_metadata = True  # cannot get time series without gld id
+            if only_metadata:
+                empty_df = pd.DataFrame()
+                return empty_df, meta
+
+            dfl = []
+            for i, gld_id in enumerate(gld_ids):
+                df, meta_new = measurements_from_gld(gld_id, **kwargs)
+                meta.update(meta_new)
+                dfl.append(df)
+            df = pd.concat(dfl, axis=0).sort_index()
         else:
-            meta["gld_ids"] = gld_ids
-
-        if only_metadata:
-            empty_df = pd.DataFrame()
-            return empty_df, meta
-
-        dfl = []
-        for i, gld_id in enumerate(gld_ids):
-            df, meta_new = measurements_from_gld(gld_id, **kwargs)
-            meta.update(meta_new)
-            dfl.append(df)
-        df = pd.concat(dfl, axis=0).sort_index()
-
-        return df, meta
+            raise ValueError(f"invalid engine selected {engine=}")
+    return df, meta
 
 
 def get_gld_ids_from_gmw(bro_id, tube_nr):
@@ -401,9 +440,8 @@ def measurements_from_gld(
     return df, meta
 
 
-def get_full_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
-    """get metadata for a groundwater monitoring well.
-
+def get_full_metadata_from_gmw_hpd(bro_id, tube_nr):
+    """get metadata for a groundwater monitoring well using the hydropandas engine.
 
     Parameters
     ----------
@@ -411,10 +449,6 @@ def get_full_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
         bro id of groundwater monitoring well e.g. 'GMW000000036287'.
     tube_nr : int
         filter number you want metadata for.
-    use_brodata : str
-        When True, use the python-package `brodata` for requesting data from the
-        bro-database. When False, use internal logic in hydropandas. The default is
-        False.
 
     Raises
     ------
@@ -425,17 +459,7 @@ def get_full_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
     -------
     meta : dict
         dictionary with metadata.
-
     """
-    if use_brodata:
-        import brodata
-
-        gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
-        _check_tube_number(bro_id, tube_nr, gmw.monitoringTube.index)
-        tube_gdf = brodata.gmw.get_tube_gdf([gmw])
-        meta = tube_gdf.loc[(bro_id, tube_nr)].to_dict()
-        return meta
-
     if not bro_id.startswith("GMW"):
         raise ValueError("can only get metadata if bro id starts with GMW")
 
@@ -499,6 +523,45 @@ def get_full_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
 
     for key, val in rename_dic.items():
         meta[val] = meta.pop(key)
+
+    return meta
+
+
+def get_full_metadata_from_gmw(bro_id, tube_nr, engine="hydropandas"):
+    """get metadata for a groundwater monitoring well.
+
+    Parameters
+    ----------
+    bro_id : str
+        bro id of groundwater monitoring well e.g. 'GMW000000036287'.
+    tube_nr : int
+        filter number you want metadata for.
+    engine : str, optional
+        Select how data from the bro-database is obtained, options are 'hydropandas' or
+        'brodata' The default is 'hydropandas'.
+
+    Raises
+    ------
+    ValueError
+        if bro_id is invalid.
+
+    Returns
+    -------
+    meta : dict
+        dictionary with metadata.
+
+    """
+    if engine == "brodata":
+        import brodata
+
+        gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
+        _check_tube_number(bro_id, tube_nr, gmw.monitoringTube.index)
+        tube_gdf = brodata.gmw.get_tube_gdf([gmw])
+        meta = tube_gdf.loc[(bro_id, tube_nr)].to_dict()
+    elif engine == "hydropandas":
+        meta = get_full_metadata_from_gmw_hpd(bro_id, tube_nr)
+    else:
+        raise ValueError(f"invalid engine selected {engine=}")
 
     return meta
 
@@ -606,9 +669,9 @@ def _brodata_gmw_to_meta(gmw, tube_nr):
     return meta
 
 
-def get_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
-    """get selection of metadata for a groundwater monitoring well.
-    coordinates, ground_level, tube_top and tube screen
+def get_metadata_from_gmw_hpd(bro_id, tube_nr):
+    """get selection of metadata for a groundwater monitoring well using the
+    hydropandas engine.
 
     Parameters
     ----------
@@ -616,10 +679,6 @@ def get_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
         bro id of groundwater monitoring well e.g. 'GMW000000036287'.
     tube_nr : int
         tube number you want metadata for.
-    use_brodata : str
-        When True, use the python-package `brodata` for requesting data from the
-        bro-database. When False, use internal logic in hydropandas. The default is
-        False.
 
     Raises
     ------
@@ -634,14 +693,6 @@ def get_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
         dictionary with metadata.
 
     """
-    if use_brodata:
-        import brodata
-
-        gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
-        _check_tube_number(bro_id, tube_nr, gmw.monitoringTube.index)
-        meta = _brodata_gmw_to_meta(gmw, tube_nr)
-
-        return meta
     if not isinstance(tube_nr, int):
         raise TypeError(f"expected integer got {type(tube_nr)}")
 
@@ -710,6 +761,47 @@ def get_metadata_from_gmw(bro_id, tube_nr, use_brodata=False):
     return meta
 
 
+def get_metadata_from_gmw(bro_id, tube_nr, engine="hydropandas"):
+    """get selection of metadata for a groundwater monitoring well.
+    coordinates, ground_level, tube_top and tube screen
+
+    Parameters
+    ----------
+    bro_id : str
+        bro id of groundwater monitoring well e.g. 'GMW000000036287'.
+    tube_nr : int
+        tube number you want metadata for.
+    engine : str, optional
+        Select how data from the bro-database is obtained, options are 'hydropandas' or
+        'brodata' The default is 'hydropandas'.
+
+    Raises
+    ------
+    ValueError
+        if bro_id is invalid.
+    TypeError
+        if tube_nr is not an int
+
+    Returns
+    -------
+    meta : dict
+        dictionary with metadata.
+
+    """
+    if engine == "brodata":
+        import brodata
+
+        gmw = brodata.gmw.GroundwaterMonitoringWell.from_bro_id(bro_id)
+        _check_tube_number(bro_id, tube_nr, gmw.monitoringTube.index)
+        meta = _brodata_gmw_to_meta(gmw, tube_nr)
+    elif engine == "hydropandas":
+        meta = get_metadata_from_gmw_hpd(bro_id, tube_nr)
+    else:
+        raise ValueError(f"invalid engine selected {engine=}")
+
+    return meta
+
+
 def _check_tube_number(bro_id, tube_nr, tube_nrs):
     if tube_nr not in tube_nrs:
         raise ValueError(
@@ -727,8 +819,7 @@ def get_obs_list_from_extent(
     keep_all_obs=True,
     epsg=28992,
     ignore_max_obs=False,
-    use_brodata=False,
-    use_gm=True,
+    engine="hydropandas",
 ):
     """get a list of gmw observations within an extent.
 
@@ -753,19 +844,16 @@ def get_obs_list_from_extent(
         by default you get a prompt if you want to download over a 1000
         observations at once. if ignore_max_obs is True you won't get the
         prompt. The default is False
-    use_brodata : str
-        When True, use the python-package `brodata` for requesting data from the
-        bro-database. When False, use internal logic in hydropandas. The default is
-        False.
-    use_gm : str
-        Only used when use_brodata=True. When use_gm=True, use the dataset
+    engine : str, optional
+        Select how data from the bro-database is obtained, options are 'hydropandas',
+        'brodata' or 'brodata_gm'. When engine='brodata_gm' use the dataset
         Grondwatermonitoring (GM) in samenhang - karakteristieken, hosted by PDOK. This
         up-to-date dataset combines well- and tube-properties. So users do not have to
         download each individual Groundwater Monitoring Well (GMW), which speeds up the
         request. The gm-dataset does not contain the attributes `tube_top` and
-        `ground_level`, so you need to set use_gm=False if you need those. The
-        Groundwater Level Dossiers (GLD) are still downloaded individually. The default
-        is True.
+        `ground_level`, so you need to use engine='brodata' or 'hydropandas' if you
+        need those. The Groundwater Level Dossiers (GLD) are still downloaded
+        individually. The default is True. The default is 'hydropandas'.
 
     Raises
     ------
@@ -784,7 +872,7 @@ def get_obs_list_from_extent(
             "you will get an empty ObsCollection with only_metadata is True and"
             "keep_all_obs is False"
         )
-    if use_brodata:
+    if "brodata" in engine:
         import brodata
 
         obs_list = []
@@ -793,16 +881,18 @@ def get_obs_list_from_extent(
         else:
             kind = "gld"
 
-        if use_gm:
+        if engine == "brodata_gm":
             # use Grondwatermonitoring (GM) in samenhang
             # so we do not have to download each individual Groundwater Monitoring Well
             gdf = brodata.gm.get_data_in_extent(
                 extent, kind=kind, tmin=tmin, tmax=tmax, combine=True
             )
-        else:
+        elif engine == "brodata":
             gdf = brodata.gmw.get_data_in_extent(
                 extent, kind=kind, tmin=tmin, tmax=tmax, combine=True
             )
+        else:
+            raise ValueError(f"invalid engine selected {engine=}")
 
         for index in gdf.index:
             kwargs = dict(
@@ -813,10 +903,10 @@ def get_obs_list_from_extent(
                 tube_nr=index[1],
                 metadata_available=True,
             )
-            if use_gm:
+            if engine == "brodata_gm":
                 kwargs["screen_top"] = gdf.at[index, "screen_top_position"]
                 kwargs["screen_bottom"] = gdf.at[index, "screen_bottom_position"]
-            else:
+            elif engine == "brodata":
                 kwargs["tube_top"] = gdf.at[index, "tubeTopPosition"]
                 kwargs["ground_level"] = gdf.at[index, "groundLevelPosition"]
                 kwargs["screen_top"] = gdf.at[index, "screenTopPosition"]
@@ -829,88 +919,91 @@ def get_obs_list_from_extent(
             obs_list.append(o)
         return obs_list
 
-    url = "https://publiek.broservices.nl/gm/gmw/v1/characteristics/searches?"
+    elif engine == "hydropandas":
+        url = "https://publiek.broservices.nl/gm/gmw/v1/characteristics/searches?"
 
-    data = {}
-    if tmin is None or tmax is None:
-        data["registrationPeriod"] = {}
-        if tmin is not None:
-            beginDate = pd.to_datetime(tmin).strftime("%Y-%m-%d")
-            data["registrationPeriod"]["beginDate"] = beginDate
-        if tmax is not None:
-            endDate = pd.to_datetime(tmax).strftime("%Y-%m-%d")
-            data["registrationPeriod"]["endDate"] = endDate
+        data = {}
+        if tmin is None or tmax is None:
+            data["registrationPeriod"] = {}
+            if tmin is not None:
+                beginDate = pd.to_datetime(tmin).strftime("%Y-%m-%d")
+                data["registrationPeriod"]["beginDate"] = beginDate
+            if tmax is not None:
+                endDate = pd.to_datetime(tmax).strftime("%Y-%m-%d")
+                data["registrationPeriod"]["endDate"] = endDate
 
-    data["area"] = {}
-    if epsg == 4326:
-        data["area"]["boundingBox"] = {
-            "lowerCorner": {"lat": extent[2], "lon": extent[0]},
-            "upperCorner": {"lat": extent[3], "lon": extent[1]},
-        }
-    else:
-        transformer = Transformer.from_crs(epsg, 4326)
-        if extent is not None:
-            lat1, lon1 = transformer.transform(extent[0], extent[2])
-            lat2, lon2 = transformer.transform(extent[1], extent[3])
+        data["area"] = {}
+        if epsg == 4326:
             data["area"]["boundingBox"] = {
-                "lowerCorner": {"lat": lat1, "lon": lon1},
-                "upperCorner": {"lat": lat2, "lon": lon2},
+                "lowerCorner": {"lat": extent[2], "lon": extent[0]},
+                "upperCorner": {"lat": extent[3], "lon": extent[1]},
             }
-    req = requests.post(url, json=data)
-    if req.status_code > 200:
-        logger.error(
-            "could not get monitoring wells, your extent is probably too big."
-            "Try a smaller extent"
-        )
-        req.raise_for_status()
-
-    # read results
-    tree = xml.etree.ElementTree.fromstring(req.text)
-
-    ns = {
-        "dsgmw": "http://www.broservices.nl/xsd/dsgmw/1.1",
-        "gml": "http://www.opengis.net/gml/3.2",
-        "brocom": "http://www.broservices.nl/xsd/brocommon/3.0",
-    }
-
-    if tree.find(".//brocom:responseType", ns).text == "rejection":
-        raise RuntimeError(tree.find(".//brocom:rejectionReason", ns).text)
-
-    gmws_ids = np.unique(
-        [gmw.text for gmw in tree.findall(".//dsgmw:GMW_C//brocom:broId", ns)]
-    )
-
-    if len(gmws_ids) > 1000 and not ignore_max_obs:
-        ans = input(
-            f"You requested to download {len(gmws_ids)} observations, this can"
-            "take a while. Are you sure you want to continue [Y/n]? "
-        )
-        if ans not in ["Y", "y", "yes", "Yes", "YES"]:
-            return []
-
-    obs_list = []
-    for gmw_id in tqdm(gmws_ids):
-        gmws = tree.findall(f'.//*[brocom:broId="{gmw_id}"]', ns)
-        if len(gmws) < 1:
-            raise RuntimeError("unexpected")
-
-        tube_nrs = get_tube_nrs_from_gmw(gmw_id)
-        for tube_nr in tube_nrs:
-            o = ObsClass.from_bro(
-                gmw_id,
-                tube_nr=tube_nr,
-                tmin=tmin,
-                tmax=tmax,
-                only_metadata=only_metadata,
+        else:
+            transformer = Transformer.from_crs(epsg, 4326)
+            if extent is not None:
+                lat1, lon1 = transformer.transform(extent[0], extent[2])
+                lat2, lon2 = transformer.transform(extent[1], extent[3])
+                data["area"]["boundingBox"] = {
+                    "lowerCorner": {"lat": lat1, "lon": lon1},
+                    "upperCorner": {"lat": lat2, "lon": lon2},
+                }
+        req = requests.post(url, json=data)
+        if req.status_code > 200:
+            logger.error(
+                "could not get monitoring wells, your extent is probably too big."
+                "Try a smaller extent"
             )
-            if o.empty:
-                logger.debug(
-                    f"no measurements found for gmw_id {gmw_id} and tube number"
-                    f"{tube_nr}"
-                )
-                if keep_all_obs:
-                    obs_list.append(o)
-            else:
-                obs_list.append(o)
+            req.raise_for_status()
 
-    return obs_list
+        # read results
+        tree = xml.etree.ElementTree.fromstring(req.text)
+
+        ns = {
+            "dsgmw": "http://www.broservices.nl/xsd/dsgmw/1.1",
+            "gml": "http://www.opengis.net/gml/3.2",
+            "brocom": "http://www.broservices.nl/xsd/brocommon/3.0",
+        }
+
+        if tree.find(".//brocom:responseType", ns).text == "rejection":
+            raise RuntimeError(tree.find(".//brocom:rejectionReason", ns).text)
+
+        gmws_ids = np.unique(
+            [gmw.text for gmw in tree.findall(".//dsgmw:GMW_C//brocom:broId", ns)]
+        )
+
+        if len(gmws_ids) > 1000 and not ignore_max_obs:
+            ans = input(
+                f"You requested to download {len(gmws_ids)} observations, this can"
+                "take a while. Are you sure you want to continue [Y/n]? "
+            )
+            if ans not in ["Y", "y", "yes", "Yes", "YES"]:
+                return []
+
+        obs_list = []
+        for gmw_id in tqdm(gmws_ids):
+            gmws = tree.findall(f'.//*[brocom:broId="{gmw_id}"]', ns)
+            if len(gmws) < 1:
+                raise RuntimeError("unexpected")
+
+            tube_nrs = get_tube_nrs_from_gmw(gmw_id)
+            for tube_nr in tube_nrs:
+                o = ObsClass.from_bro(
+                    gmw_id,
+                    tube_nr=tube_nr,
+                    tmin=tmin,
+                    tmax=tmax,
+                    only_metadata=only_metadata,
+                )
+                if o.empty:
+                    logger.debug(
+                        f"no measurements found for gmw_id {gmw_id} and tube number"
+                        f"{tube_nr}"
+                    )
+                    if keep_all_obs:
+                        obs_list.append(o)
+                else:
+                    obs_list.append(o)
+
+        return obs_list
+    else:
+        raise ValueError(f"invalid engine selected {engine=}")

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1808,13 +1808,13 @@ class ObsCollection(pd.DataFrame):
         ObsCollection
         """
         d = d.copy()
-        assert (
-            "obstype" in d
-        ), "dictionary should contain an 'obstype' key with the observation type"
+        assert "obstype" in d, (
+            "dictionary should contain an 'obstype' key with the observation type"
+        )
         obstype = d.pop("obstype")
-        assert (
-            cls.__name__ == obstype
-        ), f"{obstype=} not an observation type supported by hydropandas"
+        assert cls.__name__ == obstype, (
+            f"{obstype=} not an observation type supported by hydropandas"
+        )
 
         df = d.pop("df", None)
         df = pd.DataFrame(df, **kwargs)
@@ -2203,13 +2203,13 @@ class ObsCollection(pd.DataFrame):
         if closing:
             fo.close()
 
-        assert (
-            "obstype" in d
-        ), "json file should contain an 'obstype' key with the observation type"
+        assert "obstype" in d, (
+            "json file should contain an 'obstype' key with the observation type"
+        )
         obstype = d.pop("obstype")
-        assert (
-            cls.__name__ == obstype
-        ), f"{obstype=} not an observation type supported by hydropandas"
+        assert cls.__name__ == obstype, (
+            f"{obstype=} not an observation type supported by hydropandas"
+        )
 
         df = pd.read_json(StringIO(d.pop("df")))
         obs_list = []

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1599,8 +1599,10 @@ class ObsCollection(pd.DataFrame):
             Grondwatermonitoring (GM) in samenhang - karakteristieken, hosted by PDOK. This
             up-to-date dataset combines well- and tube-properties. So users do not have to
             download each individual Groundwater Monitoring Well (GMW), which speeds up the
-            request. The Groundwater Level Dossiers (GLD) are still downloaded individually.
-            The default is True.
+            request. The gm-dataset does not contain the attributes `tube_top` and
+            `ground_level`, so you need to set use_gm=False if you need those. The
+            Groundwater Level Dossiers (GLD) are still downloaded individually. The default
+            is True.
 
         Returns
         -------

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -36,6 +36,7 @@ def read_bro(
     keep_all_obs=True,
     epsg=28992,
     ignore_max_obs=False,
+    method="internal",
 ):
     """Get all the observations within an extent or within a groundwatermonitoring net.
 
@@ -64,6 +65,10 @@ def read_bro(
         by default you get a prompt if you want to download over a 1000
         observations at once. if ignore_max_obs is True you won't get the
         prompt. The default is False
+    method : str
+        The method to use for requesting data from the bro-database. When method is
+        'internal', use internal logic in hydropandas. When method is 'brodata', use the
+        python-package `brodata`. The default is 'internal'.
 
     Returns
     -------
@@ -81,6 +86,7 @@ def read_bro(
         keep_all_obs=keep_all_obs,
         epsg=epsg,
         ignore_max_obs=ignore_max_obs,
+        method=method,
     )
 
     return oc
@@ -1553,6 +1559,7 @@ class ObsCollection(pd.DataFrame):
         keep_all_obs=True,
         epsg=28992,
         ignore_max_obs=False,
+        method="internal",
     ):
         """Get all the observations within an extent or within a groundwatermonitoring
         net.
@@ -1582,6 +1589,10 @@ class ObsCollection(pd.DataFrame):
             by default you get a prompt if you want to download over a 1000
             observations at once. if ignore_max_obs is True you won't get the
             prompt. The default is False
+        method : str
+            The method to use for requesting data from the bro-database. When method is
+            'internal', use internal logic in hydropandas. When method is 'brodata', use the
+            python-package `brodata`. The default is 'internal'.
 
         Returns
         -------
@@ -1601,6 +1612,7 @@ class ObsCollection(pd.DataFrame):
                 keep_all_obs=keep_all_obs,
                 epsg=epsg,
                 ignore_max_obs=ignore_max_obs,
+                method=method,
             )
             meta = {}
         elif bro_id is not None:
@@ -1609,6 +1621,7 @@ class ObsCollection(pd.DataFrame):
                 obs.GroundwaterObs,
                 only_metadata=only_metadata,
                 keep_all_obs=keep_all_obs,
+                method=method,
             )
             name = meta.pop("name")
         else:
@@ -1795,13 +1808,13 @@ class ObsCollection(pd.DataFrame):
         ObsCollection
         """
         d = d.copy()
-        assert "obstype" in d, (
-            "dictionary should contain an 'obstype' key with the observation type"
-        )
+        assert (
+            "obstype" in d
+        ), "dictionary should contain an 'obstype' key with the observation type"
         obstype = d.pop("obstype")
-        assert cls.__name__ == obstype, (
-            f"{obstype=} not an observation type supported by hydropandas"
-        )
+        assert (
+            cls.__name__ == obstype
+        ), f"{obstype=} not an observation type supported by hydropandas"
 
         df = d.pop("df", None)
         df = pd.DataFrame(df, **kwargs)
@@ -2190,13 +2203,13 @@ class ObsCollection(pd.DataFrame):
         if closing:
             fo.close()
 
-        assert "obstype" in d, (
-            "json file should contain an 'obstype' key with the observation type"
-        )
+        assert (
+            "obstype" in d
+        ), "json file should contain an 'obstype' key with the observation type"
         obstype = d.pop("obstype")
-        assert cls.__name__ == obstype, (
-            f"{obstype=} not an observation type supported by hydropandas"
-        )
+        assert (
+            cls.__name__ == obstype
+        ), f"{obstype=} not an observation type supported by hydropandas"
 
         df = pd.read_json(StringIO(d.pop("df")))
         obs_list = []

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -36,7 +36,7 @@ def read_bro(
     keep_all_obs=True,
     epsg=28992,
     ignore_max_obs=False,
-    method="internal",
+    use_brodata=False,
 ):
     """Get all the observations within an extent or within a groundwatermonitoring net.
 
@@ -65,10 +65,10 @@ def read_bro(
         by default you get a prompt if you want to download over a 1000
         observations at once. if ignore_max_obs is True you won't get the
         prompt. The default is False
-    method : str
-        The method to use for requesting data from the bro-database. When method is
-        'internal', use internal logic in hydropandas. When method is 'brodata', use the
-        python-package `brodata`. The default is 'internal'.
+    use_brodata : str
+        When True, use the python-package `brodata` for requesting data from the
+        bro-database. When False, use internal logic in hydropandas. The default is
+        False.
 
     Returns
     -------
@@ -86,7 +86,7 @@ def read_bro(
         keep_all_obs=keep_all_obs,
         epsg=epsg,
         ignore_max_obs=ignore_max_obs,
-        method=method,
+        use_brodata=use_brodata,
     )
 
     return oc
@@ -1559,7 +1559,8 @@ class ObsCollection(pd.DataFrame):
         keep_all_obs=True,
         epsg=28992,
         ignore_max_obs=False,
-        method="internal",
+        use_brodata=False,
+        use_gm=True,
     ):
         """Get all the observations within an extent or within a groundwatermonitoring
         net.
@@ -1589,10 +1590,17 @@ class ObsCollection(pd.DataFrame):
             by default you get a prompt if you want to download over a 1000
             observations at once. if ignore_max_obs is True you won't get the
             prompt. The default is False
-        method : str
-            The method to use for requesting data from the bro-database. When method is
-            'internal', use internal logic in hydropandas. When method is 'brodata', use the
-            python-package `brodata`. The default is 'internal'.
+        use_brodata : str
+            When True, use the python-package `brodata` for requesting data from the
+            bro-database. When False, use internal logic in hydropandas. The default is
+            False.
+        use_gm : str
+            Only used when use_brodata=True. When use_gm=True, use the dataset
+            Grondwatermonitoring (GM) in samenhang - karakteristieken, hosted by PDOK. This
+            up-to-date dataset combines well- and tube-properties. So users do not have to
+            download each individual Groundwater Monitoring Well (GMW), which speeds up the
+            request. The Groundwater Level Dossiers (GLD) are still downloaded individually.
+            The default is True.
 
         Returns
         -------
@@ -1612,7 +1620,8 @@ class ObsCollection(pd.DataFrame):
                 keep_all_obs=keep_all_obs,
                 epsg=epsg,
                 ignore_max_obs=ignore_max_obs,
-                method=method,
+                use_brodata=use_brodata,
+                use_gm=use_gm,
             )
             meta = {}
         elif bro_id is not None:
@@ -1621,7 +1630,7 @@ class ObsCollection(pd.DataFrame):
                 obs.GroundwaterObs,
                 only_metadata=only_metadata,
                 keep_all_obs=keep_all_obs,
-                method=method,
+                use_brodata=use_brodata,
             )
             name = meta.pop("name")
         else:

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -36,7 +36,7 @@ def read_bro(
     keep_all_obs=True,
     epsg=28992,
     ignore_max_obs=False,
-    use_brodata=False,
+    engine="hydropandas",
 ):
     """Get all the observations within an extent or within a groundwatermonitoring net.
 
@@ -65,10 +65,9 @@ def read_bro(
         by default you get a prompt if you want to download over a 1000
         observations at once. if ignore_max_obs is True you won't get the
         prompt. The default is False
-    use_brodata : str
-        When True, use the python-package `brodata` for requesting data from the
-        bro-database. When False, use internal logic in hydropandas. The default is
-        False.
+    engine : str, optional
+        Select how data from the bro-database is obtained, options are 'hydropandas' or
+        'brodata' The default is 'hydropandas'.
 
     Returns
     -------
@@ -86,7 +85,7 @@ def read_bro(
         keep_all_obs=keep_all_obs,
         epsg=epsg,
         ignore_max_obs=ignore_max_obs,
-        use_brodata=use_brodata,
+        engine=engine,
     )
 
     return oc
@@ -1559,8 +1558,7 @@ class ObsCollection(pd.DataFrame):
         keep_all_obs=True,
         epsg=28992,
         ignore_max_obs=False,
-        use_brodata=False,
-        use_gm=True,
+        engine="hydropandas",
     ):
         """Get all the observations within an extent or within a groundwatermonitoring
         net.
@@ -1590,19 +1588,17 @@ class ObsCollection(pd.DataFrame):
             by default you get a prompt if you want to download over a 1000
             observations at once. if ignore_max_obs is True you won't get the
             prompt. The default is False
-        use_brodata : str
-            When True, use the python-package `brodata` for requesting data from the
-            bro-database. When False, use internal logic in hydropandas. The default is
-            False.
-        use_gm : str
-            Only used when use_brodata=True. When use_gm=True, use the dataset
-            Grondwatermonitoring (GM) in samenhang - karakteristieken, hosted by PDOK. This
+        engine : str, optional
+            Select how data from the bro-database is obtained, options are 'hydropandas',
+            'brodata' or 'brodata_gm'. 'brodata_gm' is only available when extent is not
+            None. When engine='brodata_gm' use the dataset Grondwatermonitoring (GM) in
+            samenhang - karakteristieken, hosted by PDOK. This
             up-to-date dataset combines well- and tube-properties. So users do not have to
             download each individual Groundwater Monitoring Well (GMW), which speeds up the
             request. The gm-dataset does not contain the attributes `tube_top` and
-            `ground_level`, so you need to set use_gm=False if you need those. The
-            Groundwater Level Dossiers (GLD) are still downloaded individually. The default
-            is True.
+            `ground_level`, so you need to use engine='brodata' or 'hydropandas' if you
+            need those. The Groundwater Level Dossiers (GLD) are still downloaded
+            individually. The default is True. The default is 'hydropandas'.
 
         Returns
         -------
@@ -1622,8 +1618,7 @@ class ObsCollection(pd.DataFrame):
                 keep_all_obs=keep_all_obs,
                 epsg=epsg,
                 ignore_max_obs=ignore_max_obs,
-                use_brodata=use_brodata,
-                use_gm=use_gm,
+                engine=engine,
             )
             meta = {}
         elif bro_id is not None:
@@ -1632,7 +1627,7 @@ class ObsCollection(pd.DataFrame):
                 obs.GroundwaterObs,
                 only_metadata=only_metadata,
                 keep_all_obs=keep_all_obs,
-                use_brodata=use_brodata,
+                engine=engine,
             )
             name = meta.pop("name")
         else:

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -848,7 +848,7 @@ class GroundwaterObs(Obs):
         to_wintertime=True,
         drop_duplicate_times=True,
         only_metadata=False,
-        method="internal",
+        use_brodata=False,
     ):
         """Download BRO groundwater observations from the server.
 
@@ -872,10 +872,10 @@ class GroundwaterObs(Obs):
         only_metadata : bool, optional
             if True only metadata is returned and no time series data. The
             default is False
-        method : str
-            The method to use for requesting data from the bro-database. When method is
-            'internal', use internal logic in hydropandas. When method is 'brodata', use the
-            python-package `brodata`. The default is 'internal'.
+        use_brodata : str
+            When True, use the python-package `brodata` for requesting data from the
+            bro-database. When False, use internal logic in hydropandas. The default is
+            False.
 
         Returns
         -------
@@ -893,7 +893,7 @@ class GroundwaterObs(Obs):
             to_wintertime=to_wintertime,
             drop_duplicate_times=drop_duplicate_times,
             only_metadata=only_metadata,
-            method=method,
+            use_brodata=use_brodata,
         )
 
         return cls(

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -56,9 +56,9 @@ def read_csv_obs(path, parse_dates=True, index_col=0, **kwargs):
         # read observation type
         obstype = buf.readline().split("Obs")[0] + "Obs"
 
-        assert (
-            obstype in globals().keys()
-        ), f"cannot read a csv file from {obstype=}, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
+        assert obstype in globals().keys(), (
+            f"cannot read a csv file from {obstype=}, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
+        )
 
     return globals()[obstype].from_csv(
         path, parse_dates=parse_dates, index_col=index_col, **kwargs
@@ -317,14 +317,14 @@ class Obs(pd.DataFrame):
         with open(path, "r") as buf:
             # read observation type
             obstype = buf.readline().split("Obs")[0] + "Obs"
-            assert (
-                cls.__name__ == obstype
-            ), f"cannot read a csv file from {obstype=} using the {cls.__name__}.from_csv method, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
+            assert cls.__name__ == obstype, (
+                f"cannot read a csv file from {obstype=} using the {cls.__name__}.from_csv method, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
+            )
 
             # read metadata
-            assert (
-                buf.readline() == "-----metadata------\n"
-            ), f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
+            assert buf.readline() == "-----metadata------\n", (
+                f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
+            )
             line = buf.readline()
             meta = {}
             while line.strip() != "":
@@ -361,9 +361,9 @@ class Obs(pd.DataFrame):
                 line = buf.readline()
 
             # read observations
-            assert (
-                buf.readline() == "-----observations------\n"
-            ), f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
+            assert buf.readline() == "-----observations------\n", (
+                f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
+            )
             df = pd.read_csv(
                 buf, index_col=index_col, parse_dates=parse_dates, **kwargs
             )
@@ -389,13 +389,13 @@ class Obs(pd.DataFrame):
             Obs object with metadata and observations from the dictionary.
         """
         d = d.copy()
-        assert (
-            "obstype" in d
-        ), "dictionary should contain an 'obstype' key with the observation type"
+        assert "obstype" in d, (
+            "dictionary should contain an 'obstype' key with the observation type"
+        )
         obstype = d.pop("obstype")
-        assert (
-            cls.__name__ == obstype
-        ), f"{obstype=} not an observation type supported by hydropandas"
+        assert cls.__name__ == obstype, (
+            f"{obstype=} not an observation type supported by hydropandas"
+        )
 
         obs_data = d.pop("obs", None)
         df = pd.DataFrame(obs_data, **kwargs)

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -56,9 +56,9 @@ def read_csv_obs(path, parse_dates=True, index_col=0, **kwargs):
         # read observation type
         obstype = buf.readline().split("Obs")[0] + "Obs"
 
-        assert obstype in globals().keys(), (
-            f"cannot read a csv file from {obstype=}, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
-        )
+        assert (
+            obstype in globals().keys()
+        ), f"cannot read a csv file from {obstype=}, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
 
     return globals()[obstype].from_csv(
         path, parse_dates=parse_dates, index_col=index_col, **kwargs
@@ -317,14 +317,14 @@ class Obs(pd.DataFrame):
         with open(path, "r") as buf:
             # read observation type
             obstype = buf.readline().split("Obs")[0] + "Obs"
-            assert cls.__name__ == obstype, (
-                f"cannot read a csv file from {obstype=} using the {cls.__name__}.from_csv method, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
-            )
+            assert (
+                cls.__name__ == obstype
+            ), f"cannot read a csv file from {obstype=} using the {cls.__name__}.from_csv method, this is probably because the csv file was not created with hydropandas. Try parsing using pandas.read_csv"
 
             # read metadata
-            assert buf.readline() == "-----metadata------\n", (
-                f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
-            )
+            assert (
+                buf.readline() == "-----metadata------\n"
+            ), f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
             line = buf.readline()
             meta = {}
             while line.strip() != "":
@@ -361,9 +361,9 @@ class Obs(pd.DataFrame):
                 line = buf.readline()
 
             # read observations
-            assert buf.readline() == "-----observations------\n", (
-                f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
-            )
+            assert (
+                buf.readline() == "-----observations------\n"
+            ), f"invalid file {path}, probably not a csv created with hydropandas. Try parsing using pandas.read_csv"
             df = pd.read_csv(
                 buf, index_col=index_col, parse_dates=parse_dates, **kwargs
             )
@@ -389,13 +389,13 @@ class Obs(pd.DataFrame):
             Obs object with metadata and observations from the dictionary.
         """
         d = d.copy()
-        assert "obstype" in d, (
-            "dictionary should contain an 'obstype' key with the observation type"
-        )
+        assert (
+            "obstype" in d
+        ), "dictionary should contain an 'obstype' key with the observation type"
         obstype = d.pop("obstype")
-        assert cls.__name__ == obstype, (
-            f"{obstype=} not an observation type supported by hydropandas"
-        )
+        assert (
+            cls.__name__ == obstype
+        ), f"{obstype=} not an observation type supported by hydropandas"
 
         obs_data = d.pop("obs", None)
         df = pd.DataFrame(obs_data, **kwargs)
@@ -848,6 +848,7 @@ class GroundwaterObs(Obs):
         to_wintertime=True,
         drop_duplicate_times=True,
         only_metadata=False,
+        method="internal",
     ):
         """Download BRO groundwater observations from the server.
 
@@ -871,6 +872,10 @@ class GroundwaterObs(Obs):
         only_metadata : bool, optional
             if True only metadata is returned and no time series data. The
             default is False
+        method : str
+            The method to use for requesting data from the bro-database. When method is
+            'internal', use internal logic in hydropandas. When method is 'brodata', use the
+            python-package `brodata`. The default is 'internal'.
 
         Returns
         -------
@@ -888,6 +893,7 @@ class GroundwaterObs(Obs):
             to_wintertime=to_wintertime,
             drop_duplicate_times=drop_duplicate_times,
             only_metadata=only_metadata,
+            method=method,
         )
 
         return cls(

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -848,7 +848,7 @@ class GroundwaterObs(Obs):
         to_wintertime=True,
         drop_duplicate_times=True,
         only_metadata=False,
-        use_brodata=False,
+        engine="hydropandas",
     ):
         """Download BRO groundwater observations from the server.
 
@@ -872,10 +872,9 @@ class GroundwaterObs(Obs):
         only_metadata : bool, optional
             if True only metadata is returned and no time series data. The
             default is False
-        use_brodata : str
-            When True, use the python-package `brodata` for requesting data from the
-            bro-database. When False, use internal logic in hydropandas. The default is
-            False.
+        engine : str, optional
+            Select how data from the bro-database is obtained, options are 'hydropandas' or
+            'brodata' The default is 'hydropandas'.
 
         Returns
         -------
@@ -893,7 +892,7 @@ class GroundwaterObs(Obs):
             to_wintertime=to_wintertime,
             drop_duplicate_times=drop_duplicate_times,
             only_metadata=only_metadata,
-            use_brodata=use_brodata,
+            engine=engine,
         )
 
         return cls(

--- a/hydropandas/serialization.py
+++ b/hydropandas/serialization.py
@@ -1,6 +1,7 @@
 import json
-from datetime import datetime
 import pathlib
+from datetime import datetime
+
 import numpy as np
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ full = [
     "netCDF4",
     "lxml",
     "pyarrow",
-    "brodata"
+    "brodata>=0.1.4"
 ]
 rtd = [
     "hydropandas[full]",

--- a/tests/test_011_bro.py
+++ b/tests/test_011_bro.py
@@ -25,7 +25,7 @@ def test_groundwater_observations():
 
 def test_groundwater_observations_brodata():
     bro_id = "GLD000000012893"
-    bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, method="brodata")
+    bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, use_brodata=True)
 
 
 def test_gld_no_monitoringnet():
@@ -65,4 +65,4 @@ def test_groundwater_obs_from_bro_id():
 
 
 def test_groundwater_obs_from_bro_id_brodata():
-    hpd.GroundwaterObs.from_bro("GMW000000030953", tube_nr=1, method="brodata")
+    hpd.GroundwaterObs.from_bro("GMW000000030953", tube_nr=1, use_brodata=True)

--- a/tests/test_011_bro.py
+++ b/tests/test_011_bro.py
@@ -53,3 +53,11 @@ def test_obs_list_from_extent():
     bro.get_obs_list_from_extent(
         extent, hpd.GroundwaterObs, tmin=None, tmax=None, epsg=28992, only_metadata=True
     )
+
+
+def test_groundwater_obs_from_bro_id():
+    hpd.GroundwaterObs.from_bro("GMW000000030953", tube_nr=1)
+
+
+def test_groundwater_obs_from_bro_id_brodata():
+    hpd.GroundwaterObs.from_bro("GMW000000030953", tube_nr=1, method="brodata")

--- a/tests/test_011_bro.py
+++ b/tests/test_011_bro.py
@@ -23,6 +23,11 @@ def test_groundwater_observations():
     bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False)
 
 
+def test_groundwater_observations_brodata():
+    bro_id = "GLD000000012893"
+    bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, method="brodata")
+
+
 def test_gld_no_monitoringnet():
     bro_id = "GLD000000013128"
     bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False)

--- a/tests/test_011_bro.py
+++ b/tests/test_011_bro.py
@@ -25,7 +25,7 @@ def test_groundwater_observations():
 
 def test_groundwater_observations_brodata():
     bro_id = "GLD000000012893"
-    bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, use_brodata=True)
+    bro.get_bro_groundwater(bro_id, tube_nr=None, only_metadata=False, engine="brodata")
 
 
 def test_gld_no_monitoringnet():
@@ -65,4 +65,4 @@ def test_groundwater_obs_from_bro_id():
 
 
 def test_groundwater_obs_from_bro_id_brodata():
-    hpd.GroundwaterObs.from_bro("GMW000000030953", tube_nr=1, use_brodata=True)
+    hpd.GroundwaterObs.from_bro("GMW000000030953", tube_nr=1, engine="brodata")


### PR DESCRIPTION
The PR adds the usage of the Python package `brodata` to download data from BRO. This is implemented by adding the parameter `use_brodata` to several methods that download data. This parameter has a default value of `False` for now, so the original methods are still used. In the future `use_brodata` may be set to True, when this new functionality has been thoroughly tested.