### PR TITLE
Improve `read_dino` docstring

### DIFF
--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -205,7 +205,7 @@ def read_dino(
     name=None,
     **kwargs,
 ):
-    """Read dino observations within an extent from the server or from a directory with
+    """Read dino observations from a directory with
     downloaded files.
 
     Parameters


### PR DESCRIPTION
According to the old docstring read_dino could read from a server and within an extent.
According to the code I get the strong impression that both are not available. And updated the docstring accordingly.