### PR TITLE
Add timezone conversion to Dutch winter time for Matroos import

### DIFF
--- a/hydropandas/io/matroos.py
+++ b/hydropandas/io/matroos.py
@@ -478,7 +478,7 @@ def get_matroos_obs(
     )
 
     # remove time zone information by transforming to dutch winter time
-    df.index = pd.to_datetime(df.index, utc=True).tz_localize(None) + pd.Timedelta(
+    df.index = df.index + pd.Timedelta(
         1, unit="h"
     )
 

--- a/hydropandas/io/matroos.py
+++ b/hydropandas/io/matroos.py
@@ -478,8 +478,6 @@ def get_matroos_obs(
     )
 
     # remove time zone information by transforming to dutch winter time
-    df.index = df.index + pd.Timedelta(
-        1, unit="h"
-    )
+    df.index = df.index + pd.Timedelta(1, unit="h")
 
     return df, meta

--- a/hydropandas/io/matroos.py
+++ b/hydropandas/io/matroos.py
@@ -477,4 +477,9 @@ def get_matroos_obs(
         parse_dates=[0],
     )
 
+    # remove time zone information by transforming to dutch winter time
+    df.index = pd.to_datetime(df.index, utc=True).tz_localize(None) + pd.Timedelta(
+        1, unit="h"
+    )
+
     return df, meta


### PR DESCRIPTION
The Matroos API returns data in GMT/UTC. This change converts the datetime index to Dutch winter time (UTC+1) to be consistent with BRO, KNMI, and Waterinfo imports.

Fixes #346