### PR TITLE
ensure dates are exported in isoformat

### DIFF
--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -2206,6 +2206,8 @@ class ObsCollection(pd.DataFrame):
         elif isinstance(path, (str, os.PathLike)):
             fo = open(path, "r")
             closing = True
+        else:
+            raise TypeError("path should be a string or a file-like object")
 
         d = json.load(fo)
         if closing:
@@ -2913,10 +2915,10 @@ class ObsCollection(pd.DataFrame):
         d = {k: getattr(self, k) for k in self._metadata}
         d["obstype"] = type(self).__name__
         if self.empty:
-            d["df"] = super().to_json()
+            d["df"] = super().to_json(date_format="iso")
             d["obs_list"] = []
         else:
-            d["df"] = super().drop(columns="obs").to_json()
+            d["df"] = super().drop(columns="obs").to_json(date_format="iso")
             d["obs_list"] = [o.to_json() for o in self.obs]
 
         if path is None:

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -762,7 +762,7 @@ class Obs(pd.DataFrame):
         None
         """
         d = self.to_dict()
-        d["obs"] = super().to_json()
+        d["obs"] = super().to_json(date_format="iso")
         if path is None:
             return json.dumps(d, cls=cls, **kwargs)
         else:

--- a/hydropandas/serialization.py
+++ b/hydropandas/serialization.py
@@ -1,22 +1,23 @@
 import json
 import pathlib
-from datetime import datetime
+from datetime import date, datetime
 
 import numpy as np
+from pandas import Timestamp
 
 
 class HydropandasEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, (np.float32, np.float64)):
-            return float(obj)
-        elif isinstance(obj, pathlib.PurePath):
-            return str(obj)
-        elif isinstance(obj, datetime):
-            return obj.isoformat()
-        elif isinstance(obj, type):
-            return f"class : {obj.__name__}"
+    def default(self, o):
+        if isinstance(o, np.integer):
+            return int(o)
+        elif isinstance(o, np.floating):
+            return float(o)
+        elif isinstance(o, (pathlib.Path, pathlib.PurePath)):
+            return str(o)
+        elif isinstance(o, (datetime, date, Timestamp)):
+            return o.isoformat()
+        elif isinstance(o, type):
+            return f"class : {o.__name__}"
 
         # Add other conversions here
-        return super().default(obj)
+        return super().default(o)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,21 +15,21 @@ maintainers = [
     { name = "D.A. Brakenhoff", email = "d.brakenhoff@artesia-water.nl" },
     { name = "M.A. Vonk", email = "m.vonk@artesia-water.nl" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "scipy",
- "pandas",
- "matplotlib",
- "tqdm",
- "requests",
- "geopandas",
- "pyproj",
- "contextily",
- "bokeh",
- "branca",
- "folium",
- "rws-ddlpy",
- "pastastore>=1.10.2",
+    "pandas",
+    "matplotlib",
+    "tqdm",
+    "requests",
+    "geopandas",
+    "pyproj",
+    "contextily",
+    "bokeh",
+    "branca",
+    "folium",
+    "rws-ddlpy",
+    "pastastore>=1.10.2",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -59,7 +59,7 @@ full = [
     "netCDF4",
     "lxml",
     "pyarrow",
-    "brodata>=0.1.4"
+    "brodata>=0.1.4",
 ]
 rtd = [
     "hydropandas[full]",
@@ -71,7 +71,7 @@ rtd = [
     "sphinx_rtd_theme",
     "Ipython",
     "nbsphinx",
-    "nbsphinx_link"
+    "nbsphinx_link",
 ]
 ruffing = ["ruff"]
 pytesting = ["hydropandas[full,rtd]", "pytest>=7", "pytest-cov", "pytest-sugar"]
@@ -95,11 +95,11 @@ extend-include = ["*.ipynb"]
 lint.extend-select = ["I"]
 show-fixes = true
 fix = true
-exclude = ["update_knmi_stations.py", "update_matroos.py",  "wiski.py"]
+exclude = ["update_knmi_stations.py", "update_matroos.py", "wiski.py"]
 lint.ignore = ["RET504", "DTZ005", "DTZ001", "SIM102", "SIM115", "PERF401"]
 
 [tool.ruff.lint.per-file-ignores]
-"knmi.py" = ["E712"] # see PR 239
+"knmi.py" = ["E712"]             # see PR 239
 "observation.py" = ["RUF012"]
 "obs_collection.py" = ["RUF012"]
 


### PR DESCRIPTION
Dates were being written as ints, and this worked fine for the hydropandas examples but in my case, `hpd.read_json()` did not recognize the ints as dates anymore on read... Not entirely sure why it worked in the one case but not the other, but this seemed to fix it. 

- address linting comments in HydropandasEncoder
- expand support for path objects and timestamps
- ruff on pyproject.toml