### PR TITLE
Add progress_callback to KNMI data loaders

### DIFF
--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -1959,6 +1959,7 @@ def get_knmi_obslist(
     starts: pd.Timestamp | list[pd.Timestamp] | None = None,
     ends: pd.Timestamp | list[pd.Timestamp] | None = None,
     ObsClasses: list[Any] | None = None,
+    progress_callback=None,
     **kwargs,
 ) -> list[Any]:
     """Get a list of observations of knmi stations. Either specify a list of
@@ -1993,6 +1994,10 @@ def get_knmi_obslist(
     ObsClasses : list of type or None
         class of the observations, can be PrecipitationObs or
         EvaporationObs. The default is None.
+    progress_callback : callable or None, optional
+        callback function that is called with (i, total) for each station
+        processed, where i is the zero-based index and total is the total
+        number of stations. The default is None.
     **kwargs:
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
@@ -2076,7 +2081,9 @@ def get_knmi_obslist(
         else:
             _stns = stns
 
-        for stn in _stns:
+        for i, stn in enumerate(_stns):
+            if progress_callback is not None:
+                progress_callback(i, len(_stns))
             o = ObsClass.from_knmi(
                 meteo_var=meteo_var,
                 stn=stn,

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -943,15 +943,22 @@ def _get_overlap_factor(
     if not valid.any():
         return 1.0, 0
 
-    ratios = (base[valid] / donor[valid]).replace([np.inf, -np.inf], np.nan).dropna()
-    if ratios.empty:
+    base_valid = base[valid].replace([np.inf, -np.inf], np.nan).dropna()
+    donor_valid = donor[valid].replace([np.inf, -np.inf], np.nan).dropna()
+    common_idx = base_valid.index.intersection(donor_valid.index)
+    if common_idx.empty:
         return 1.0, 0
 
-    factor = float(ratios.median())
+    base_sum = float(base_valid.loc[common_idx].sum())
+    donor_sum = float(donor_valid.loc[common_idx].sum())
+    if donor_sum == 0.0:
+        return 1.0, 0
+
+    factor = base_sum / donor_sum
     if not np.isfinite(factor) or (factor <= 0):
         return 1.0, 0
 
-    return factor, int(ratios.size)
+    return factor, int(common_idx.size)
 
 
 def download_knmi_data(

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -80,6 +80,11 @@ def get_knmi_obs(
             end the data from nearby stations is used. In this case the metadata of the
             Observation is the metadata from the nearest station that has any
             measurement in the given period.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -315,6 +320,11 @@ def _get_default_settings(settings=None) -> dict[str, Any]:
     The default settings are:
     fill_missing_obs = False
         nan values in time series are filled with nearby time series.
+    fill_missing_obs_with_factor = False
+        if True, and overlapping measurements exist between the current
+        series and a donor station, donor values are scaled by an overlap-
+        based factor before filling missing values. This automatically enables
+        fill_missing_obs.
     interval = 'daily'
         desired time interval for observations. Can be 'daily' or 'hourly'.
         'hourly' is only for precipitation ('RH') data from meteo stations.
@@ -341,6 +351,7 @@ def _get_default_settings(settings=None) -> dict[str, Any]:
 
     default_settings = {
         "fill_missing_obs": False,
+        "fill_missing_obs_with_factor": False,
         "interval": "daily",
         "use_api": True,
         "raise_exceptions": True,
@@ -348,6 +359,13 @@ def _get_default_settings(settings=None) -> dict[str, Any]:
 
     if settings is None:
         settings = {}
+
+    if settings.get("fill_missing_obs_with_factor", False):
+        if not settings.get("fill_missing_obs", False):
+            logger.debug(
+                "set fill_missing_obs=True because fill_missing_obs_with_factor is True"
+            )
+        settings["fill_missing_obs"] = True
 
     if "fill_missing_obs" in settings:
         if "raise_exceptions" in settings:
@@ -389,9 +407,9 @@ def get_knmi_timeseries_stn(
     settings : dict
         settings for obtaining the right time series, see _get_default_settings
         for more information
-    start : pd.TimeStamp or None, optional
+    start : pd.Timestamp or None, optional
         start date of observations. The default is None.
-    end : pd.TimeStamp or None, optional
+    end : pd.Timestamp or None, optional
         end date of observations. The default is None.
 
     Returns
@@ -429,9 +447,9 @@ def get_timeseries_stn(
     settings : dict
         settings for obtaining the right time series, see _get_default_settings
         for more information
-    start : pd.TimeStamp or None, optional
+    start : pd.Timestamp or None, optional
         start date of observations. The default is None.
-    end : pd.TimeStamp or None, optional
+    end : pd.Timestamp or None, optional
         end date of observations. The default is None.
 
     Returns
@@ -659,9 +677,9 @@ def fill_missing_measurements(
         measurement station.
     meteo_var : str
         observation type.
-    start : pd.TimeStamp
+    start : pd.Timestamp
         start date of observations.
-    end : pd.TimeStamp
+    end : pd.Timestamp
         end date of observations.
     settings : dict
         settings for obtaining data.
@@ -678,6 +696,8 @@ def fill_missing_measurements(
         metadata from the originally requested station even if this station
         has no data
     """
+    use_overlap_factor = settings.get("fill_missing_obs_with_factor", False)
+
     if settings["interval"] == "hourly":
         raise NotImplementedError("cannot yet fill missing values in hourly data")
 
@@ -861,6 +881,16 @@ def fill_missing_measurements(
         else:
             # dropnans from new data
             ts_df_comp = ts_df_comp.loc[~ts_df_comp[meteo_var].isna(), :]
+            if use_overlap_factor:
+                factor, n_overlap = _get_overlap_factor(ts_df, ts_df_comp, meteo_var)
+                if factor != 1.0:
+                    ts_df_comp = ts_df_comp.copy()
+                    ts_df_comp[meteo_var] = ts_df_comp[meteo_var] * factor
+                    logger.info(
+                        f"Scale station {stn_comp} data with factor {factor:.3f} "
+                        f"based on overlap with station {stn} "
+                        f"using {n_overlap} measurements"
+                    )
             # get index of missing data in original timeseries
             missing_idx = missing.loc[missing].index
             # if any missing are in the new data, update
@@ -888,6 +918,42 @@ def fill_missing_measurements(
     return ts_df, meta
 
 
+def _get_overlap_factor(
+    ts_df: pd.DataFrame, ts_df_comp: pd.DataFrame, meteo_var: str
+) -> tuple[float, int]:
+    """Estimate scaling factor from overlap between two station series.
+
+    The returned factor scales donor-station values so they better align with
+    the current series before filling missing values.
+    """
+    if (meteo_var not in ts_df.columns) or (meteo_var not in ts_df_comp.columns):
+        return 1.0, 0
+
+    overlap = pd.concat(
+        [ts_df.loc[:, [meteo_var]], ts_df_comp.loc[:, [meteo_var]]],
+        axis=1,
+        keys=["base", "donor"],
+    ).dropna()
+    if overlap.empty:
+        return 1.0, 0
+
+    base = overlap[("base", meteo_var)]
+    donor = overlap[("donor", meteo_var)]
+    valid = donor != 0
+    if not valid.any():
+        return 1.0, 0
+
+    ratios = (base[valid] / donor[valid]).replace([np.inf, -np.inf], np.nan).dropna()
+    if ratios.empty:
+        return 1.0, 0
+
+    factor = float(ratios.median())
+    if not np.isfinite(factor) or (factor <= 0):
+        return 1.0, 0
+
+    return factor, int(ratios.size)
+
+
 def download_knmi_data(
     stn: int,
     meteo_var: str,
@@ -905,9 +971,9 @@ def download_knmi_data(
         measurement station.
     meteo_var : str
         observation type.
-    start : pd.TimeStamp
+    start : pd.Timestamp
         start date of observations.
-    end : pd.TimeStamp
+    end : pd.Timestamp
         end date of observations.
     settings : dict
         settings for obtaining data
@@ -1025,9 +1091,9 @@ def get_knmi_daily_rainfall_api(
     ----------
     stn : int
         station number.
-    start : pd.TimeStamp or None
+    start : pd.Timestamp or None
         start time of observations.
-    end : pd.TimeStamp or None
+    end : pd.Timestamp or None
         end time of observations.
 
     Raises
@@ -1063,9 +1129,9 @@ def get_daily_rainfall_api(
     ----------
     stn : int
         station number.
-    start : pd.TimeStamp or None
+    start : pd.Timestamp or None
         start time of observations.
-    end : pd.TimeStamp or None
+    end : pd.Timestamp or None
         end time of observations.
 
     Raises
@@ -1332,9 +1398,9 @@ def get_knmi_daily_meteo_api(
         station number.
     meteo_var : str
         e.g. 'EV24'.
-    start : pd.TimeStamp or None
+    start : pd.Timestamp or None
         start time of observations.
-    end : pd.TimeStamp or None
+    end : pd.Timestamp or None
         end time of observations.
 
     Returns
@@ -1368,9 +1434,9 @@ def get_daily_meteo_api(
         station number.
     meteo_var : str
         e.g. 'EV24'.
-    start : pd.TimeStamp or None
+    start : pd.Timestamp or None
         start time of observations.
-    end : pd.TimeStamp or None
+    end : pd.Timestamp or None
         end time of observations.
 
     Returns
@@ -1562,9 +1628,9 @@ def interpret_knmi_file(
         dictionary with meteo_var as key
     meteo_var : str
         e.g. 'EV24'.
-    start : pd.TimeStamp or None
+    start : pd.Timestamp or None
         start time of observations.
-    end : pd.TimeStamp or None
+    end : pd.Timestamp or None
         end time of observations.
     add_day : boolean, optional
         add 1 day so that the timestamp is at the end of the period the data describes,
@@ -1906,9 +1972,9 @@ def _add_missing_indices(
         column to see which station is used to fill the value
     stn : int or str
         measurement station.
-    start : pd.TimeStamp
+    start : pd.Timestamp
         start time of observations.
-    end : pd.TimeStamp
+    end : pd.Timestamp
         end time of observations.
 
     Returns
@@ -2005,6 +2071,11 @@ def get_knmi_obslist(
             end the data from nearby stations is used. In this case the metadata of the
             Observation is the metadata from the nearest station that has any
             measurement in the given period.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -2113,9 +2184,9 @@ def get_evaporation(
         Choice between 'penman', 'makkink' or 'hargraves'.
     stn : str
         station number, defaults to 260 De Bilt
-    start : pd.TimeStamp
+    start : pd.Timestamp
         start time of observations.
-    end : pd.TimeStamp
+    end : pd.Timestamp
         end time of observations.
     settings : dict or None, optional
         settings for the time series

--- a/hydropandas/io/knmi.py
+++ b/hydropandas/io/knmi.py
@@ -668,7 +668,7 @@ def fill_missing_measurements(
     end: pd.Timestamp,
     settings: dict[str, Any],
     stn_name: str | None = None,
-) -> tuple[pd.DataFrame, dict[str, Any], pd.DataFrame]:
+) -> tuple[pd.DataFrame, dict[str, Any]]:
     """fill missing measurements in knmi data.
 
     Parameters
@@ -939,19 +939,16 @@ def _get_overlap_factor(
 
     base = overlap[("base", meteo_var)]
     donor = overlap[("donor", meteo_var)]
-    valid = donor != 0
-    if not valid.any():
-        return 1.0, 0
 
-    base_valid = base[valid].replace([np.inf, -np.inf], np.nan).dropna()
-    donor_valid = donor[valid].replace([np.inf, -np.inf], np.nan).dropna()
+    base_valid = base.replace([np.inf, -np.inf], np.nan).dropna()
+    donor_valid = donor.replace([np.inf, -np.inf], np.nan).dropna()
     common_idx = base_valid.index.intersection(donor_valid.index)
     if common_idx.empty:
         return 1.0, 0
 
     base_sum = float(base_valid.loc[common_idx].sum())
     donor_sum = float(donor_valid.loc[common_idx].sum())
-    if donor_sum == 0.0:
+    if donor_sum == 0.0 or base_sum == 0.0:
         return 1.0, 0
 
     factor = base_sum / donor_sum

--- a/hydropandas/io/wow.py
+++ b/hydropandas/io/wow.py
@@ -378,9 +378,9 @@ def _start_end_to_datetime(start: str | None, end: str | None) -> tuple[pd.Times
 
     Returns
     -------
-    start : pd.TimeStamp
+    start : pd.Timestamp
         start time
-    end : pd.TimeStamp
+    end : pd.Timestamp
         end time
     """
 

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -468,6 +468,7 @@ def read_knmi(
     ends=None,
     ObsClasses=None,
     fill_missing_obs=False,
+    fill_missing_obs_with_factor=False,
     interval="daily",
     use_api=True,
     raise_exceptions=True,
@@ -509,6 +510,14 @@ def read_knmi(
         class of the observations, can be PrecipitationObs, EvaporationObs
         or MeteoObs. If None the type of observations is derived from the
         meteo_vars.
+    fill_missing_obs : bool, optional
+        if True nan values in time series are filled with nearby time series.
+        The default is False.
+    fill_missing_obs_with_factor : bool, optional
+        if True, donor-station values are scaled with an overlap-based factor
+        before filling missing values. This automatically enables
+        fill_missing_obs.
+        The default is False.
     progress_callback : callable or None, optional
         callback function called with (i, total) for each station processed.
         The default is None.
@@ -630,6 +639,7 @@ def read_knmi(
         ends=ends,
         ObsClasses=ObsClasses,
         fill_missing_obs=fill_missing_obs,
+        fill_missing_obs_with_factor=fill_missing_obs_with_factor,
         interval=interval,
         use_api=use_api,
         raise_exceptions=raise_exceptions,
@@ -2321,6 +2331,7 @@ class ObsCollection(pd.DataFrame):
         ends=None,
         ObsClasses=None,
         fill_missing_obs=False,
+        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
@@ -2364,6 +2375,11 @@ class ObsCollection(pd.DataFrame):
             meteo_vars.
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
+            The default is False.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
             The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
@@ -2430,6 +2446,7 @@ class ObsCollection(pd.DataFrame):
             ends=ends,
             ObsClasses=ObsClasses,
             fill_missing_obs=fill_missing_obs,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -471,6 +471,7 @@ def read_knmi(
     interval="daily",
     use_api=True,
     raise_exceptions=True,
+    progress_callback=None,
 ):
     """Get knmi observations from a list of locations or a list of stations.
 
@@ -508,6 +509,9 @@ def read_knmi(
         class of the observations, can be PrecipitationObs, EvaporationObs
         or MeteoObs. If None the type of observations is derived from the
         meteo_vars.
+    progress_callback : callable or None, optional
+        callback function called with (i, total) for each station processed.
+        The default is None.
     **kwargs :
         kwargs are passed to the hydropandas.io.knmi.get_knmi_obslist function
 
@@ -629,6 +633,7 @@ def read_knmi(
         interval=interval,
         use_api=use_api,
         raise_exceptions=raise_exceptions,
+        progress_callback=progress_callback,
     )
 
     return oc
@@ -2319,6 +2324,7 @@ class ObsCollection(pd.DataFrame):
         interval="daily",
         use_api=True,
         raise_exceptions=True,
+        progress_callback=None,
     ):
         """Get knmi observations from a list of locations or a list of stations.
 
@@ -2370,6 +2376,9 @@ class ObsCollection(pd.DataFrame):
             online (July 2021).
         raise_exceptions : bool, optional
             if True you get errors when no data is returned. The default is False.
+        progress_callback : callable or None, optional
+            callback function called with (i, total) for each station processed.
+            The default is None.
         **kwargs :
             kwargs are passed to the `hydropandas.io.knmi.get_knmi_obslist` function
         """
@@ -2424,6 +2433,7 @@ class ObsCollection(pd.DataFrame):
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,
+            progress_callback=progress_callback,
         )
 
         obs_df = util._obslist_to_frame(obs_list)

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -468,11 +468,11 @@ def read_knmi(
     ends=None,
     ObsClasses=None,
     fill_missing_obs=False,
-    fill_missing_obs_with_factor=False,
     interval="daily",
     use_api=True,
     raise_exceptions=True,
     progress_callback=None,
+    fill_missing_obs_with_factor=False,
 ):
     """Get knmi observations from a list of locations or a list of stations.
 
@@ -513,14 +513,14 @@ def read_knmi(
     fill_missing_obs : bool, optional
         if True nan values in time series are filled with nearby time series.
         The default is False.
+    progress_callback : callable or None, optional
+        callback function called with (i, total) for each station processed.
+        The default is None.
     fill_missing_obs_with_factor : bool, optional
         if True, donor-station values are scaled with an overlap-based factor
         before filling missing values. This automatically enables
         fill_missing_obs.
         The default is False.
-    progress_callback : callable or None, optional
-        callback function called with (i, total) for each station processed.
-        The default is None.
     **kwargs :
         kwargs are passed to the hydropandas.io.knmi.get_knmi_obslist function
 
@@ -639,11 +639,11 @@ def read_knmi(
         ends=ends,
         ObsClasses=ObsClasses,
         fill_missing_obs=fill_missing_obs,
-        fill_missing_obs_with_factor=fill_missing_obs_with_factor,
         interval=interval,
         use_api=use_api,
         raise_exceptions=raise_exceptions,
         progress_callback=progress_callback,
+        fill_missing_obs_with_factor=fill_missing_obs_with_factor,
     )
 
     return oc
@@ -2331,11 +2331,11 @@ class ObsCollection(pd.DataFrame):
         ends=None,
         ObsClasses=None,
         fill_missing_obs=False,
-        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
         progress_callback=None,
+        fill_missing_obs_with_factor=False,
     ):
         """Get knmi observations from a list of locations or a list of stations.
 
@@ -2376,11 +2376,6 @@ class ObsCollection(pd.DataFrame):
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
             The default is False.
-        fill_missing_obs_with_factor : bool, optional
-            if True, donor-station values are scaled with an overlap-based factor
-            before filling missing values. This automatically enables
-            fill_missing_obs.
-            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -2395,6 +2390,11 @@ class ObsCollection(pd.DataFrame):
         progress_callback : callable or None, optional
             callback function called with (i, total) for each station processed.
             The default is None.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
         **kwargs :
             kwargs are passed to the `hydropandas.io.knmi.get_knmi_obslist` function
         """
@@ -2446,11 +2446,11 @@ class ObsCollection(pd.DataFrame):
             ends=ends,
             ObsClasses=ObsClasses,
             fill_missing_obs=fill_missing_obs,
-            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,
             progress_callback=progress_callback,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
         )
 
         obs_df = util._obslist_to_frame(obs_list)

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -1600,12 +1600,12 @@ class MeteoObs(Obs):
         start=None,
         end=None,
         fill_missing_obs=False,
-        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
         startdate=None,
         enddate=None,
+        fill_missing_obs_with_factor=False,
     ):
         """Get a MeteoObs timeseries from the KNMI meteo data.
 
@@ -1631,11 +1631,6 @@ class MeteoObs(Obs):
             end the data from nearby stations is used. In this case the metadata of the
             Observation is the metadata from the nearest station that has any
             measurement in the given period.
-        fill_missing_obs_with_factor : bool, optional
-            if True, donor-station values are scaled with an overlap-based factor
-            before filling missing values. This automatically enables
-            fill_missing_obs.
-            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -1647,6 +1642,11 @@ class MeteoObs(Obs):
             online (July 2021).
         raise_exceptions : bool, optional
             if True you get errors when no data is returned. The default is False.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
 
         Returns
         -------
@@ -1671,10 +1671,10 @@ class MeteoObs(Obs):
             start=start,
             end=end,
             fill_missing_obs=fill_missing_obs,
-            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
         )
 
         return cls(
@@ -1764,12 +1764,12 @@ class EvaporationObs(MeteoObs):
         start=None,
         end=None,
         fill_missing_obs=False,
-        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
         startdate=None,
         enddate=None,
+        fill_missing_obs_with_factor=False,
     ):
         """Get an EvaporationObs timeseries from the KNMI evaporation in m.
 
@@ -1791,11 +1791,6 @@ class EvaporationObs(MeteoObs):
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
             The default is False.
-        fill_missing_obs_with_factor : bool, optional
-            if True, donor-station values are scaled with an overlap-based factor
-            before filling missing values. This automatically enables
-            fill_missing_obs.
-            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -1809,6 +1804,11 @@ class EvaporationObs(MeteoObs):
             if False a text file is downloaded into a temporary directory and the
             data is read from there. Default is True since the api is back
             online (July 2021).
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
 
 
         Returns
@@ -1824,12 +1824,12 @@ class EvaporationObs(MeteoObs):
             start=start,
             end=end,
             fill_missing_obs=fill_missing_obs,
-            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,
             startdate=startdate,
             enddate=enddate,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
         )
 
 
@@ -1861,12 +1861,12 @@ class PrecipitationObs(MeteoObs):
         start=None,
         end=None,
         fill_missing_obs=False,
-        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
         startdate=None,
         enddate=None,
+        fill_missing_obs_with_factor=False,
     ):
         """Get a PrecipitationObs timeseries from the KNMI precipitation. The
         precipitation is the Daily precipitation amount (in 0.1 mm) (-1 for.
@@ -1909,11 +1909,6 @@ class PrecipitationObs(MeteoObs):
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
             The default is False.
-        fill_missing_obs_with_factor : bool, optional
-            if True, donor-station values are scaled with an overlap-based factor
-            before filling missing values. This automatically enables
-            fill_missing_obs.
-            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -1925,6 +1920,11 @@ class PrecipitationObs(MeteoObs):
             online (July 2021).
         raise_exceptions : bool, optional
             if True you get errors when no data is returned. The default is False.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
 
         Returns
         -------

--- a/hydropandas/observation.py
+++ b/hydropandas/observation.py
@@ -1600,6 +1600,7 @@ class MeteoObs(Obs):
         start=None,
         end=None,
         fill_missing_obs=False,
+        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
@@ -1630,6 +1631,11 @@ class MeteoObs(Obs):
             end the data from nearby stations is used. In this case the metadata of the
             Observation is the metadata from the nearest station that has any
             measurement in the given period.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -1665,6 +1671,7 @@ class MeteoObs(Obs):
             start=start,
             end=end,
             fill_missing_obs=fill_missing_obs,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,
@@ -1757,6 +1764,7 @@ class EvaporationObs(MeteoObs):
         start=None,
         end=None,
         fill_missing_obs=False,
+        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
@@ -1782,6 +1790,11 @@ class EvaporationObs(MeteoObs):
             end date of observations. The default is None.
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
+            The default is False.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
             The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
@@ -1811,6 +1824,7 @@ class EvaporationObs(MeteoObs):
             start=start,
             end=end,
             fill_missing_obs=fill_missing_obs,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,
@@ -1847,6 +1861,7 @@ class PrecipitationObs(MeteoObs):
         start=None,
         end=None,
         fill_missing_obs=False,
+        fill_missing_obs_with_factor=False,
         interval="daily",
         use_api=True,
         raise_exceptions=True,
@@ -1894,6 +1909,11 @@ class PrecipitationObs(MeteoObs):
         fill_missing_obs : bool, optional
             if True nan values in time series are filled with nearby time series.
             The default is False.
+        fill_missing_obs_with_factor : bool, optional
+            if True, donor-station values are scaled with an overlap-based factor
+            before filling missing values. This automatically enables
+            fill_missing_obs.
+            The default is False.
         interval : str, optional
             desired time interval for observations. Options are 'daily' and
             'hourly'. The default is 'daily'.
@@ -1924,6 +1944,7 @@ class PrecipitationObs(MeteoObs):
             start=start,
             end=end,
             fill_missing_obs=fill_missing_obs,
+            fill_missing_obs_with_factor=fill_missing_obs_with_factor,
             interval=interval,
             use_api=use_api,
             raise_exceptions=raise_exceptions,

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -451,6 +451,27 @@ def test_obslist_from_stns_single_startdate():
     )
 
 
+def test_obslist_progress_callback():
+    stns = [344, 260]  # Rotterdam en de Bilt
+    calls = []
+
+    def cb(i, total):
+        calls.append((i, total))
+
+    knmi.get_knmi_obslist(
+        stns=stns,
+        meteo_vars=["RH"],
+        starts="2010",
+        ends="2010",
+        ObsClasses=[hpd.PrecipitationObs],
+        progress_callback=cb,
+    )
+
+    assert len(calls) == len(stns)
+    assert calls[0] == (0, len(stns))
+    assert calls[-1] == (len(stns) - 1, len(stns))
+
+
 def test_knmi_scenarios_obs_collection_and_filter():
     # download a small subset of scenario data for a single station
     oc = hpd.ObsCollection.from_knmi_scenarios(

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -419,82 +419,56 @@ def test_fill_missing_obs_with_factor_enables_fill_missing_obs():
     assert settings["raise_exceptions"] is False
 
 
-def test_fill_missing_measurements_with_overlap_factor(monkeypatch):
-    stations = pd.DataFrame(
-        {
-            "lon": [0.0, 0.0, 0.0],
-            "lat": [0.0, 0.0, 0.0],
-            "name": ["A", "B", "DE BILT"],
-            "x": [0.0, 1.0, 2.0],
-            "y": [0.0, 1.0, 2.0],
-            "altitude": [0.0, 0.0, 0.0],
-            "tmin": ["1900-01-01", "1900-01-01", "1900-01-01"],
-            "tmax": [None, None, None],
-        },
-        index=[100, 200, 260],
+def test_fill_missing_measurements_with_overlap_factor():
+    # Use a real-data period where station 72 (RD) is partially filled by station 78.
+    stn = 72
+    meteo_var = "RD"
+    start = pd.Timestamp("1986-03-25")
+    end = pd.Timestamp("1986-03-29")
+    stn_name = knmi.get_station_name(
+        stn, stations=knmi.get_stations(meteo_var=meteo_var)
     )
-
-    base_idx = pd.to_datetime(["2000-01-01", "2000-01-02", "2000-01-04"])
-    base_ts = pd.DataFrame({"RH": [10.0, 20.0, 40.0]}, index=base_idx)
-
-    donor_idx = pd.to_datetime(["2000-01-02", "2000-01-03", "2000-01-04"])
-    donor_ts = pd.DataFrame({"RH": [10.0, 15.0, 20.0]}, index=donor_idx)
-
-    def fake_get_stations(meteo_var, start=None, end=None):
-        return stations.copy()
-
-    def fake_get_nearest_station_df(
-        locations,
-        xcol="x",
-        ycol="y",
-        stations=None,
-        meteo_var="RH",
-        start=None,
-        end=None,
-        ignore=None,
-    ):
-        if ignore is None:
-            return [200]
-        return [s for s in [200] if s not in ignore] or None
-
-    def fake_download_knmi_data(stn, meteo_var, start, end, settings, stn_name=None):
-        if stn == 100:
-            return base_ts.copy(), {}, pd.DataFrame(index=[100])
-        if stn == 200:
-            return donor_ts.copy(), {}, pd.DataFrame(index=[200])
-        return pd.DataFrame(columns=[meteo_var]), {}, pd.DataFrame(index=[stn])
-
-    monkeypatch.setattr(knmi, "get_stations", fake_get_stations)
-    monkeypatch.setattr(knmi, "get_station_name", lambda stn, stations=None: f"S{stn}")
-    monkeypatch.setattr(knmi, "get_nearest_station_df", fake_get_nearest_station_df)
-    monkeypatch.setattr(knmi, "download_knmi_data", fake_download_knmi_data)
 
     settings_no_factor = knmi._get_default_settings(
         {"fill_missing_obs": True, "fill_missing_obs_with_factor": False}
     )
-    df_no_factor, _ = knmi.fill_missing_measurements(
-        stn=100,
-        meteo_var="RH",
-        start=pd.Timestamp("2000-01-01"),
-        end=pd.Timestamp("2000-01-04"),
-        settings=settings_no_factor,
-        stn_name="S100",
-    )
-
     settings_factor = knmi._get_default_settings(
         {"fill_missing_obs": True, "fill_missing_obs_with_factor": True}
     )
+
+    df_no_factor, _ = knmi.fill_missing_measurements(
+        stn=stn,
+        meteo_var=meteo_var,
+        start=start,
+        end=end,
+        settings=settings_no_factor,
+        stn_name=stn_name,
+    )
     df_factor, _ = knmi.fill_missing_measurements(
-        stn=100,
-        meteo_var="RH",
-        start=pd.Timestamp("2000-01-01"),
-        end=pd.Timestamp("2000-01-04"),
+        stn=stn,
+        meteo_var=meteo_var,
+        start=start,
+        end=end,
         settings=settings_factor,
-        stn_name="S100",
+        stn_name=stn_name,
     )
 
-    assert df_no_factor.loc[pd.Timestamp("2000-01-03"), "RH"] == 15.0
-    assert df_factor.loc[pd.Timestamp("2000-01-03"), "RH"] == 30.0
+    common_idx = df_no_factor.index.intersection(df_factor.index)
+    donor_idx = common_idx[
+        (df_no_factor.loc[common_idx, "station"].astype(str) != str(stn))
+        & (df_factor.loc[common_idx, "station"].astype(str) != str(stn))
+    ]
+    changed_idx = donor_idx[
+        (
+            df_no_factor.loc[donor_idx, meteo_var] - df_factor.loc[donor_idx, meteo_var]
+        ).abs()
+        > 1e-12
+    ]
+
+    assert donor_idx.size > 0, "expected filled values from nearby station(s)"
+    assert changed_idx.size > 0, (
+        "expected overlap-factor scaling to alter filled values"
+    )
 
 
 def test_obslist_from_grid():

--- a/tests/test_006_knmi.py
+++ b/tests/test_006_knmi.py
@@ -411,6 +411,92 @@ def test_fill_missing_measurements_neerslag():
     # assert not df.empty, "expected filled df"
 
 
+def test_fill_missing_obs_with_factor_enables_fill_missing_obs():
+    settings = knmi._get_default_settings({"fill_missing_obs_with_factor": True})
+
+    assert settings["fill_missing_obs_with_factor"] is True
+    assert settings["fill_missing_obs"] is True
+    assert settings["raise_exceptions"] is False
+
+
+def test_fill_missing_measurements_with_overlap_factor(monkeypatch):
+    stations = pd.DataFrame(
+        {
+            "lon": [0.0, 0.0, 0.0],
+            "lat": [0.0, 0.0, 0.0],
+            "name": ["A", "B", "DE BILT"],
+            "x": [0.0, 1.0, 2.0],
+            "y": [0.0, 1.0, 2.0],
+            "altitude": [0.0, 0.0, 0.0],
+            "tmin": ["1900-01-01", "1900-01-01", "1900-01-01"],
+            "tmax": [None, None, None],
+        },
+        index=[100, 200, 260],
+    )
+
+    base_idx = pd.to_datetime(["2000-01-01", "2000-01-02", "2000-01-04"])
+    base_ts = pd.DataFrame({"RH": [10.0, 20.0, 40.0]}, index=base_idx)
+
+    donor_idx = pd.to_datetime(["2000-01-02", "2000-01-03", "2000-01-04"])
+    donor_ts = pd.DataFrame({"RH": [10.0, 15.0, 20.0]}, index=donor_idx)
+
+    def fake_get_stations(meteo_var, start=None, end=None):
+        return stations.copy()
+
+    def fake_get_nearest_station_df(
+        locations,
+        xcol="x",
+        ycol="y",
+        stations=None,
+        meteo_var="RH",
+        start=None,
+        end=None,
+        ignore=None,
+    ):
+        if ignore is None:
+            return [200]
+        return [s for s in [200] if s not in ignore] or None
+
+    def fake_download_knmi_data(stn, meteo_var, start, end, settings, stn_name=None):
+        if stn == 100:
+            return base_ts.copy(), {}, pd.DataFrame(index=[100])
+        if stn == 200:
+            return donor_ts.copy(), {}, pd.DataFrame(index=[200])
+        return pd.DataFrame(columns=[meteo_var]), {}, pd.DataFrame(index=[stn])
+
+    monkeypatch.setattr(knmi, "get_stations", fake_get_stations)
+    monkeypatch.setattr(knmi, "get_station_name", lambda stn, stations=None: f"S{stn}")
+    monkeypatch.setattr(knmi, "get_nearest_station_df", fake_get_nearest_station_df)
+    monkeypatch.setattr(knmi, "download_knmi_data", fake_download_knmi_data)
+
+    settings_no_factor = knmi._get_default_settings(
+        {"fill_missing_obs": True, "fill_missing_obs_with_factor": False}
+    )
+    df_no_factor, _ = knmi.fill_missing_measurements(
+        stn=100,
+        meteo_var="RH",
+        start=pd.Timestamp("2000-01-01"),
+        end=pd.Timestamp("2000-01-04"),
+        settings=settings_no_factor,
+        stn_name="S100",
+    )
+
+    settings_factor = knmi._get_default_settings(
+        {"fill_missing_obs": True, "fill_missing_obs_with_factor": True}
+    )
+    df_factor, _ = knmi.fill_missing_measurements(
+        stn=100,
+        meteo_var="RH",
+        start=pd.Timestamp("2000-01-01"),
+        end=pd.Timestamp("2000-01-04"),
+        settings=settings_factor,
+        stn_name="S100",
+    )
+
+    assert df_no_factor.loc[pd.Timestamp("2000-01-03"), "RH"] == 15.0
+    assert df_factor.loc[pd.Timestamp("2000-01-03"), "RH"] == 30.0
+
+
 def test_obslist_from_grid():
     xy = [[x, y] for x in [104150.0, 104550.0] for y in [510150.0, 510550.0]]
 


### PR DESCRIPTION
# Add progress_callback
Introduce an optional `progress_callback` parameter to `hydropandas.io.knmi.get_knmi_obslist` and the public `read_knmi` wrappers (module-level function and ObsCollection methods). The callback, if provided, is called as progress_callback(i, total) for each station processed (i is zero-based index, total is number of stations). The default remains None and behavior is backward-compatible; the callback is invoked inside the station processing loop.

# Add overlap-scaling for filling missing KNMI data
Introduce a new setting `fill_missing_obs_with_factor` that scales donor-station values by an overlap-based factor before filling missing KNMI observations (automatically enables `fill_missing_obs`). Implement `_get_overlap_factor` to estimate a ratio from overlapping measurements and apply it in `fill_missing_measurements` (with logging).