### PR TITLE
fix for #378 - preserve metadata columns when `merge_metadata=False`

### DIFF
--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1764,12 +1764,12 @@ class ObsCollection(pd.DataFrame):
 
             # overwrite observation in collection
             d = omerged.to_collection_dict()
-            if kwargs.get("merge_metadata", False):
-                # keep values in existing columns that are not in d
-                oc.loc[o.name, d.keys()] = d
-            else:
+            if kwargs.get("merge_metadata", True):
                 # clears existing columns that are not in d
                 oc.loc[o.name] = d
+            else:
+                # keep values in existing columns that are not in d
+                oc.loc[o.name, d.keys()] = d
 
         if not inplace:
             return oc

--- a/hydropandas/obs_collection.py
+++ b/hydropandas/obs_collection.py
@@ -1763,7 +1763,13 @@ class ObsCollection(pd.DataFrame):
             omerged = o1.merge_observation(o, **kwargs)
 
             # overwrite observation in collection
-            oc.loc[o.name] = omerged.to_collection_dict()
+            d = omerged.to_collection_dict()
+            if kwargs.get("merge_metadata", False):
+                # keep values in existing columns that are not in d
+                oc.loc[o.name, d.keys()] = d
+            else:
+                # clears existing columns that are not in d
+                oc.loc[o.name] = d
 
         if not inplace:
             return oc


### PR DESCRIPTION
- when merge_metadata is False, we can safely keep the data in the additional columns, so only update the fields included in the merged obs
- when merge_metadata is True, the metadata columns might be stale after merge, so making them NaN is perhaps fair, and repopulating the metadata columns using `oc.add_meta_to_df()` is probably the way to go.
- the downside is that user added columns will also be nulled, but perhaps that is okay?